### PR TITLE
fix: DynamoDB の item_type フィルタで旧アプリ行が消える不具合を修正する

### DIFF
--- a/ecscd/src/lib/infrastructure/dynamodb.ts
+++ b/ecscd/src/lib/infrastructure/dynamodb.ts
@@ -48,9 +48,12 @@ export class DynamoDB implements IDatabase {
 
   async getApplications(): Promise<ApplicationDomain[]> {
     try {
+      // item_type 属性が無いアイテムは item_type 導入前に書き込まれたアプリケーション行
+      // なので、フィルタなしと同じ扱いにする (filter アイテムは item_type="filter" を
+      // 必ず持つため、属性なし = 旧アプリ行)。
       const command = new ScanCommand({
         TableName: this.tableName,
-        FilterExpression: "item_type = :item_type",
+        FilterExpression: "attribute_not_exists(item_type) OR item_type = :item_type",
         ExpressionAttributeValues: {
           ":item_type": "application",
         },
@@ -78,7 +81,7 @@ export class DynamoDB implements IDatabase {
     try {
       const command = new ScanCommand({
         TableName: this.tableName,
-        FilterExpression: "item_type = :item_type",
+        FilterExpression: "attribute_not_exists(item_type) OR item_type = :item_type",
         ExpressionAttributeValues: {
           ":item_type": "application",
         },


### PR DESCRIPTION
## Summary
- `item_type` 属性のない既存アイテム(`item_type` 導入前に書き込まれたアプリ行)が `getApplications`/`getApplicationNames` の `FilterExpression` で全件除外され、アップグレード直後にダッシュボードが空になる不具合を修正
- `filter` アイテムは `item_type="filter"` を必ず持つため、属性なし = 旧アプリ行として扱ってよい

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`