### PR TITLE
fix: fable レビューで指摘された FIXME を解消する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# ビルドコンテキストからローカル生成物を除外する。
+# 特に ecscd/.next はホストの古いビルド (削除済みルートを参照する型検証ファイル) を
+# 含むことがあり、COPY されると next build の型チェックが壊れる。
+.git
+docs
+tools
+compose.yaml
+**/node_modules
+ecscd/.next
+ecscd/coverage
+ecscd/ecscd.db
+ecscd/tsconfig.tsbuildinfo
+# 統合テストは実行イメージに不要 (devDependencies 前提のため型チェックも通らない)
+ecscd/tests
+ecscd/jest.config.js
+ecscd/jest.integration.config.js

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ npm run dev
 
 アプリケーションは `http://localhost:3000` でアクセスできます。
 
+### ローカル動作確認 / 統合テスト (MiniStack)
+
+実 AWS アカウントなしで動作確認・自動テストを行える構成があります。ローカル環境を汚さず
+すべてコンテナで完結し、実際の ECS のような非同期デプロイ遷移・ロールバックも試せます。
+
+```bash
+docker compose up -d --build
+open http://localhost:3000
+```
+
+詳細は [docs/local-verification.md](docs/local-verification.md) を参照してください。
+
 ## アーキテクチャ
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ npm run dev
 
 ### ローカル動作確認 / 統合テスト (MiniStack)
 
-実 AWS アカウントなしで動作確認・自動テストを行える構成があります。ローカル環境を汚さず
-すべてコンテナで完結し、実際の ECS のような非同期デプロイ遷移・ロールバックも試せます。
+実 AWS アカウントなしで、AWS エミュレータ ([MiniStack](https://github.com/ministackorg/ministack)) と
+GitHub API スタブを使った動作確認・統合テストができます。ローカル環境を汚さずすべてコンテナで完結し、
+実際の ECS のような非同期デプロイ遷移・ロールバックも試せます。
 
 ```bash
+# 動作確認 (http://localhost:3000 に demo-app が表示される)
 docker compose up -d --build
-open http://localhost:3000
+
+# 統合テスト
+docker compose --profile test run --rm integration-test
 ```
 
 詳細は [docs/local-verification.md](docs/local-verification.md) を参照してください。

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,130 @@
+# ローカル動作確認・自動テスト用スタック。
+# ministack (AWS エミュレータ) / ecs-sim / github-stub / ecscd をすべてコンテナで
+# 起動し、ローカル環境には何もインストールしない。
+#
+#   動作確認:  docker compose up -d --build
+#              → http://localhost:3000 (demo-app が OutOfSync で表示される)
+#   自動テスト: docker compose --profile test run --rm integration-test
+#   後片付け:  docker compose --profile test down -v
+name: ecscd-local
+
+networks:
+  default:
+    name: ecscd-local
+
+services:
+  # AWS エミュレータ (DynamoDB / STS)。ポート 4566。
+  ministack:
+    image: ministackorg/ministack:latest
+    ports:
+      # ホスト側ポートは MINISTACK_PORT で変更可能 (他プロジェクトと衝突する場合)
+      - "${MINISTACK_PORT:-4566}:4566"
+    environment:
+      DOCKER_NETWORK: ecscd-local
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  # ECS シミュレータ。MiniStack の ECS は UpdateService が同期的に COMPLETED を
+  # 返し ListServiceDeployments も未実装のため、実際の ECS のような非同期の
+  # ロールアウト遷移・ロールバックを試せない。このサーバがそのギャップを埋める
+  # (tools/ecs-sim/server.js 参照。依存パッケージなし)。
+  ecs-sim:
+    image: node:24-slim
+    command: ["node", "/sim/server.js"]
+    ports:
+      # ホスト側ポートは ECS_SIM_PORT で変更可能 (他プロジェクトと衝突する場合)
+      - "${ECS_SIM_PORT:-4600}:8081"
+    environment:
+      PORT: "8081"
+      AWS_REGION: us-east-1
+      # ロールアウト所要時間 (ms) と結果分布。数秒〜数十秒でランダムに
+      # success/hang(スタックしたまま進まない=ロールバック演習用)/failed に遷移する。
+      ECS_SIM_ROLLOUT_MIN_MS: "8000"
+      ECS_SIM_ROLLOUT_MAX_MS: "25000"
+      ECS_SIM_ROLLBACK_DURATION_MS: "4000"
+      ECS_SIM_OUTCOME_WEIGHTS: "success:0.7,hang:0.2,failed:0.1"
+    volumes:
+      - ./tools/ecs-sim:/sim:ro
+
+  # GitHub REST API のスタブ。tools/github-stub/data/ 配下のファイルを
+  # /repos/{owner}/{repo}/contents/{path} として返す (依存パッケージなし)。
+  github-stub:
+    image: node:24-slim
+    command: ["node", "/stub/server.js"]
+    environment:
+      PORT: "8080"
+      DATA_DIR: /stub/data
+    volumes:
+      - ./tools/github-stub:/stub:ro
+
+  # ministack (DynamoDB) / ecs-sim (ECS) にデモ用リソースを投入するワンショット
+  # ジョブ。冪等。
+  ministack-init:
+    image: amazon/aws-cli:latest
+    entrypoint: ["/bin/sh", "/init/init.sh"]
+    environment:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://ministack:4566
+      AWS_ENDPOINT_URL_ECS: http://ecs-sim:8081
+    volumes:
+      - ./tools/ministack-init:/init:ro
+    depends_on:
+      - ministack
+      - ecs-sim
+
+  # ecscd 本体。AWS SDK v3 は AWS_ENDPOINT_URL[_<SERVICE>] を標準サポートしている
+  # ため、コード変更なしで ministack (DynamoDB/STS) と ecs-sim (ECS) を向く。
+  # GitHub API はスタブへ向ける。
+  ecscd:
+    build: .
+    ports:
+      # ホスト側ポートは ECSCD_PORT で変更可能 (他プロジェクトと衝突する場合)
+      - "${ECSCD_PORT:-3000}:3000"
+    environment:
+      DATABASE_TYPE: dynamodb
+      DYNAMODB_TABLE_NAME: ECSCD
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://ministack:4566
+      AWS_ENDPOINT_URL_ECS: http://ecs-sim:8081
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      GITHUB_TOKEN: local-dummy-token
+      GITHUB_API_URL: http://github-stub:8080
+    depends_on:
+      ministack-init:
+        condition: service_completed_successfully
+      github-stub:
+        condition: service_started
+
+  # 統合テストランナー (docker compose --profile test run --rm integration-test)。
+  # ソースはバインドマウントするが node_modules は名前付きボリュームに隔離し、
+  # ホスト側の node_modules (macOS 用ネイティブバイナリ) を汚さない。
+  integration-test:
+    profiles: ["test"]
+    image: node:24-slim
+    working_dir: /app
+    command:
+      [
+        "sh",
+        "-c",
+        "npm ci --ignore-scripts --no-audit --no-fund && npm run test:integration",
+      ]
+    environment:
+      AWS_ENDPOINT_URL: http://ministack:4566
+      AWS_ENDPOINT_URL_ECS: http://ecs-sim:8081
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+    volumes:
+      - ./ecscd:/app
+      - integration-node-modules:/app/node_modules
+    depends_on:
+      ministack-init:
+        condition: service_completed_successfully
+      ecs-sim:
+        condition: service_started
+
+volumes:
+  integration-node-modules:

--- a/docs/local-verification.md
+++ b/docs/local-verification.md
@@ -1,0 +1,121 @@
+# ローカル動作確認 / 統合テスト (MiniStack + ecs-sim)
+
+[MiniStack](https://github.com/ministackorg/ministack)(LocalStack 互換のローカル AWS エミュレータ)を使い、
+実 AWS アカウントなしで ecscd の動作確認と自動テストを行うための構成です。
+**すべてコンテナで完結し、ローカル環境には何もインストールしません。**
+
+## 構成
+
+`compose.yaml` に以下のサービスが定義されています(ネットワーク: `ecscd-local`)。
+
+| サービス | 役割 |
+| --- | --- |
+| `ministack` | AWS エミュレータ (DynamoDB / STS)。ホストの `localhost:4566` にも公開 |
+| `ecs-sim` | ECS シミュレータ。実際の ECS のような非同期ロールアウト遷移とロールバックを再現する自作サーバ (下記参照)。ホストの `localhost:4600` にも公開 |
+| `github-stub` | GitHub REST API の最小スタブ。`tools/github-stub/data/` をタスク定義の取得元として返す |
+| `ministack-init` | デモ用リソース投入のワンショットジョブ(冪等)。DynamoDB テーブル `ECSCD`(ministack)、ECS `demo-cluster`/`demo-service`(ecs-sim)、アプリケーション `demo-app` を作成 |
+| `ecscd` | ecscd 本体(ルートの `Dockerfile` でビルド)。`http://localhost:3000` |
+| `integration-test` | 統合テストランナー(profile `test`。通常の `up` では起動しない) |
+
+ecscd 側に必要だった変更は「Octokit の baseUrl を `GITHUB_API_URL` で差し替え可能にする」ことのみです。
+AWS SDK v3 は `AWS_ENDPOINT_URL` / サービス単位の `AWS_ENDPOINT_URL_<SERVICE>` を標準サポートしているため、
+AWS クライアントはコード変更なしで DynamoDB/STS は ministack、ECS は ecs-sim を向きます。
+
+## ecs-sim: 実際の ECS のような非同期デプロイを再現する
+
+MiniStack の ECS 実装は `UpdateService` が同期的に `COMPLETED` を返し、`ListServiceDeployments` も
+未実装(常に空配列)のため、実際の ECS のように「デプロイ直後は `IN_PROGRESS`、数秒〜数十秒後に
+`COMPLETED`/`FAILED` へ遷移する」挙動やロールバックを試すことができませんでした。
+`tools/ecs-sim/server.js`(依存パッケージなし)はこのギャップを埋めるため、ecscd が使う ECS API
+(RegisterTaskDefinition / DescribeTaskDefinition / DescribeServices / UpdateService /
+ListServiceDeployments / StopServiceDeployment など)をインメモリで実装し、経過時間ベースで
+ロールアウト状態を計算します。
+
+**Sync するたびに、ロールアウトはランダムに 3 パターンのいずれかになります**(`ECS_SIM_OUTCOME_WEIGHTS` で調整可能。デフォルト `success:0.7,hang:0.2,failed:0.1`):
+
+- `success`(70%): `ECS_SIM_ROLLOUT_MIN_MS`〜`ECS_SIM_ROLLOUT_MAX_MS`(デフォルト 8〜25 秒)かけて
+  `IN_PROGRESS` → `COMPLETED` に遷移します。ダッシュボードの "Deploying..." アニメーションと
+  ポーリングによるステータス遷移を確認できます。
+- `hang`(20%): 進捗が 40% 前後でスタックしたまま `IN_PROGRESS` から進まなくなります(タスクが
+  健全化できず止まったケースの再現)。この間 **Rollback** ボタンが表示され、押すと
+  `StopServiceDeployment` が呼ばれて旧タスク定義に戻ります(数秒で `COMPLETED` に遷移)。
+- `failed`(10%): 所要時間経過後に `FAILED` のまま停止します("Failed" 表示の確認用)。
+
+結果を固定して確実に試したい場合は、`ecs-sim` の制御用エンドポイント(AWS プロトコルとは別、
+非 AWS の素の HTTP)で次回のロールアウトを強制できます:
+
+```bash
+# 次に demo-service に対して UpdateService が呼ばれたとき、hang (ロールバック演習用) を強制する
+curl -X POST http://localhost:4600/_sim/next-deployment \
+  -H "Content-Type: application/json" \
+  -d '{"cluster":"demo-cluster","service":"demo-service","outcome":"hang","durationMs":3000}'
+
+# 現在の全サービスの状態をダンプ (デバッグ用)
+curl http://localhost:4600/_sim/state
+```
+
+`outcome` は `success` / `hang` / `failed` のいずれか。フォースした設定は次回の Sync 1 回分だけ有効です。
+
+## 動作確認
+
+```bash
+docker compose up -d --build
+open http://localhost:3000
+```
+
+初期状態では `demo-app` が **OutOfSync** で表示されます。
+これは Git 側(github-stub)のタスク定義にだけ環境変数 `DEPLOYED_FROM=git` が入っているためです。
+
+- **Sync** を押すと、Git 側のタスク定義が新リビジョンとして登録され、`demo-service` に反映されます
+- `tools/github-stub/data/task-definition.json` を編集すると「Git 上の望ましい状態」を変更でき、
+  ダッシュボードの差分表示が追随します(github-stub はリクエストごとにファイルを読み直すため再起動不要)
+
+状態をリセットしたいときは:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+## 自動テスト(統合テスト)
+
+統合テスト(`ecscd/tests/integration/`)は MiniStack に対して実際に AWS API を発行します。
+ユニットテスト(`npm test`)からは分離されており、jest 設定も別です(`ecscd/jest.integration.config.js`)。
+
+### コンテナで実行(推奨・CI 向け)
+
+```bash
+docker compose --profile test run --rm integration-test
+```
+
+`node_modules` は名前付きボリュームに隔離されるため、ホストの `node_modules` には影響しません。
+
+### ホストから実行(開発時の反復向け)
+
+```bash
+docker compose up -d ministack          # エミュレータだけ起動
+cd ecscd && npm run test:integration    # localhost:4566 に接続
+```
+
+### テスト内容
+
+| スイート | 検証内容 |
+| --- | --- |
+| `dynamodb.test.ts` | DynamoDB リポジトリの CRUD、重複作成の拒否、フィルタ CRUD、フィルタ行がアプリ一覧に混入しないこと |
+| `ecs.test.ts` | タスク定義の register → describe 往復と正規化(AWS 付与フィールドの除去)、describeServices、updateService |
+| `observe.test.ts` | observe → sync のエンドツーエンド(InSync → Git 側変更で OutOfSync → syncService で InSync に復帰)、不正 URL のエラーハンドリング |
+
+テストはリソース名を毎回ユニークに生成するため、デモ用スタックと同居でき、
+MiniStack のリセットも不要です。
+
+## 既知の制限
+
+- **サーバ側デフォルトによる幻の差分**: DescribeTaskDefinition はタスクレベル `cpu`/`memory` や
+  空文字の `taskRoleArn` 等を補完して返します(ecs-sim もこれを再現します)。Git 側のタスク定義が
+  これらを省略していると「Removed」差分が出て OutOfSync になるため、デモ用フィクスチャはデフォルト
+  値まで明示しています(実 AWS でもコンテナレベル `cpu: 0` の補完などで同種の現象が起こり得ます)
+- **ecs-sim の状態はプロセス内メモリのみ**: `docker compose down` や `ecs-sim` の再起動で
+  クラスタ・サービス・タスク定義・ロールアウト履歴はすべて失われます。再度 `up` すると
+  `ministack-init` が demo 用リソースを作り直します
+- **rolloutState が IN_PROGRESS のときのみ Rollback ボタンが表示される**: 現行 UI 実装
+  (`hasActiveDeployment = status === "Deploying"`)の仕様で、`FAILED` になった後は
+  ロールバックできません(Sync をやり直すことで新しいロールアウトとして上書きは可能)

--- a/docs/local-verification.md
+++ b/docs/local-verification.md
@@ -60,8 +60,9 @@ curl http://localhost:4600/_sim/state
 
 ```bash
 docker compose up -d --build
-open http://localhost:3000
 ```
+
+ブラウザで http://localhost:3000 を開いてください。
 
 初期状態では `demo-app` が **OutOfSync** で表示されます。
 これは Git 側(github-stub)のタスク定義にだけ環境変数 `DEPLOYED_FROM=git` が入っているためです。

--- a/docs/local-verification.md
+++ b/docs/local-verification.md
@@ -93,8 +93,8 @@ docker compose --profile test run --rm integration-test
 ### ホストから実行(開発時の反復向け)
 
 ```bash
-docker compose up -d ministack          # エミュレータだけ起動
-cd ecscd && npm run test:integration    # localhost:4566 に接続
+docker compose up -d ministack ecs-sim  # エミュレータだけ起動
+cd ecscd && npm run test:integration    # localhost:4566 (DynamoDB/STS) / localhost:4600 (ECS) に接続
 ```
 
 ### テスト内容

--- a/ecscd/jest.integration.config.js
+++ b/ecscd/jest.integration.config.js
@@ -1,6 +1,7 @@
 /**
- * ministack (ローカル AWS エミュレータ) に対して実際に API を発行する統合テスト用設定。
- * 事前に `docker compose up -d ministack` (または compose --profile test) が必要。
+ * ministack (DynamoDB/STS) と ecs-sim (ECS) に対して実際に API を発行する
+ * 統合テスト用設定。
+ * 事前に `docker compose up -d ministack ecs-sim` (または compose --profile test) が必要。
  * 実行: npm run test:integration
  * @type {import('jest').Config}
  */

--- a/ecscd/jest.integration.config.js
+++ b/ecscd/jest.integration.config.js
@@ -1,0 +1,32 @@
+/**
+ * ministack (ローカル AWS エミュレータ) に対して実際に API を発行する統合テスト用設定。
+ * 事前に `docker compose up -d ministack` (または compose --profile test) が必要。
+ * 実行: npm run test:integration
+ * @type {import('jest').Config}
+ */
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests/integration'],
+  testMatch: ['**/*.test.ts'],
+  setupFiles: ['<rootDir>/tests/integration/setup-env.js'],
+  // エミュレータ相手の実 API 呼び出しのため余裕を持たせる
+  testTimeout: 120000,
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  // @octokit v22 は ESM-only のため、CJS で動く jest でも読めるよう
+  // ts-jest (allowJs) で該当パッケージ群だけ変換する
+  transform: {
+    '^.+\\.[tj]sx?$': ['ts-jest', {
+      tsconfig: {
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        allowJs: true,
+      },
+    }],
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@octokit|universal-user-agent|before-after-hook|fast-content-type-parse|universal-github-app-jwt)/)',
+  ],
+};
+
+module.exports = config;

--- a/ecscd/package.json
+++ b/ecscd/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:integration": "jest --config jest.integration.config.js --runInBand"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.990.0",

--- a/ecscd/src/app/(dashboard)/layout.tsx
+++ b/ecscd/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,15 @@
+import { Suspense } from "react";
+
+// (dashboard) 配下のページは全て ApplicationDashboard をレンダリングするため、
+// キャッシュ設定 (force-dynamic) と Suspense 境界をここに一元化する。
+// 個々の page.tsx に重複して書くと、片方だけ更新漏れが起きて Full Route Cache に
+// 古い一覧・フィルタが残り続けるおそれがある。
+export const dynamic = "force-dynamic";
+
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return <Suspense fallback={null}>{children}</Suspense>;
 }

--- a/ecscd/src/app/(dashboard)/page.tsx
+++ b/ecscd/src/app/(dashboard)/page.tsx
@@ -1,8 +1,5 @@
 import { ApplicationDashboard } from "@/components/dashboard/application-dashboard";
 import { getDashboardConfigs, getDashboardFilters } from "@/lib/server/dashboard";
-import { Suspense } from "react";
-
-export const dynamic = "force-dynamic";
 
 export default async function DashboardIndexPage() {
   const [applications, filters] = await Promise.all([
@@ -11,11 +8,9 @@ export default async function DashboardIndexPage() {
   ]);
 
   return (
-    <Suspense fallback={null}>
-      <ApplicationDashboard
-        applications={applications}
-        filters={filters}
-      />
-    </Suspense>
+    <ApplicationDashboard
+      applications={applications}
+      filters={filters}
+    />
   );
 }

--- a/ecscd/src/components/application/edit-application-dialog.tsx
+++ b/ecscd/src/components/application/edit-application-dialog.tsx
@@ -21,6 +21,7 @@ interface EditApplicationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   application: ApplicationDomain | null;
+  hasActiveDeployment?: boolean;
   onSuccess?: () => void;
   onDelete?: (applicationName: string) => Promise<void>;
 }
@@ -38,7 +39,7 @@ interface ApplicationFormData {
   sessionName?: string;
 }
 
-export function EditApplicationDialog({ open, onOpenChange, application, onSuccess, onDelete }: EditApplicationDialogProps) {
+export function EditApplicationDialog({ open, onOpenChange, application, hasActiveDeployment = false, onSuccess, onDelete }: EditApplicationDialogProps) {
   const [formData, setFormData] = useState<ApplicationFormData>({
     name: '',
     clusterName: '',
@@ -183,7 +184,6 @@ export function EditApplicationDialog({ open, onOpenChange, application, onSucce
     try {
       await onDelete(application.name);
       onOpenChange(false);
-      onSuccess?.();
     } catch (error) {
       console.error("Failed to delete application:", error);
       setErrors({
@@ -342,7 +342,12 @@ export function EditApplicationDialog({ open, onOpenChange, application, onSucce
                 type="button"
                 variant="destructive"
                 onClick={handleDelete}
-                disabled={isSubmitting || isDeleting}
+                disabled={isSubmitting || isDeleting || hasActiveDeployment}
+                title={
+                  hasActiveDeployment
+                    ? "Cannot delete while a deployment is in progress"
+                    : undefined
+                }
               >
                 {isDeleting ? (
                   <>
@@ -365,7 +370,15 @@ export function EditApplicationDialog({ open, onOpenChange, application, onSucce
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isSubmitting || isDeleting}>
+              <Button
+                type="submit"
+                disabled={isSubmitting || isDeleting || hasActiveDeployment}
+                title={
+                  hasActiveDeployment
+                    ? "Cannot update while a deployment is in progress"
+                    : undefined
+                }
+              >
                 {isSubmitting ? (
                   <>
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/ecscd/src/components/dashboard/application-dashboard.tsx
+++ b/ecscd/src/components/dashboard/application-dashboard.tsx
@@ -44,6 +44,7 @@ type ApplicationDashboardProps = {
 
 type CacheEntry = {
   data?: ObservedApplicationDomain;
+  error?: string;
   promise?: Promise<void>;
 };
 
@@ -84,11 +85,16 @@ function getCachedApplication(
   config: ApplicationDomain,
 ): ObservedApplicationDomain | null {
   const entry = applicationCache.get(config.name);
-  if (!entry?.data) {
-    return null;
+  if (entry?.data) {
+    return entry.data;
+  }
+  // entry.error はキャッシュに恒久保存しない一時的な失敗なので、表示のためだけに
+  // その場で Error 状態へ変換する (次の loadApplication では再試行される)。
+  if (entry?.error) {
+    return createApplicationErrorState(config, entry.error);
   }
 
-  return entry.data;
+  return null;
 }
 
 export function ApplicationDashboard({
@@ -193,12 +199,19 @@ export function ApplicationDashboard({
         }
 
         entry.data = (await response.json()) as ObservedApplicationDomain;
+        entry.error = undefined;
       } catch (error) {
         const reason =
           error instanceof Error
             ? error.message
             : "Failed to load latest application state.";
-        entry.data = createApplicationErrorState(config, reason);
+        // 失敗結果は entry.data ではなく entry.error に保持する。entry.data のままだと
+        // loadApplication 冒頭の `existing?.data && !force` に引っかかり、一時的な
+        // ネットワーク失敗や削除→再作成(404)後もセッション中ずっと Error 表示になる
+        // (router.refresh() はこのモジュールキャッシュに触れない)。entry.error にしておけば
+        // 次の loadApplication (force なし) が自然に再試行してくれる。
+        entry.data = undefined;
+        entry.error = reason;
       } finally {
         entry.promise = undefined;
         applicationCache.set(config.name, entry);
@@ -224,23 +237,46 @@ export function ApplicationDashboard({
     }
   }, [loadApplication, nameFilteredApplications, selectedApplicationConfig]);
 
+  // 選択中かどうかに関わらず、キャッシュ上 "Deploying" の全アプリを 5 秒間隔で
+  // force 再取得する。選択中アプリだけを対象にすると、アプリ A を Sync してから
+  // アプリ B や / へ移動した際に A のキャッシュが更新されなくなり、ロールアウト
+  // 完了後もサイドバーの A が無期限に "Deploying" 表示のままになってしまう。
+  const deployingApplicationNames = useMemo(
+    () =>
+      applications
+        .filter(
+          (application) =>
+            getApplicationStatus(getCachedApplication(application) || application)
+              .status === "Deploying"
+        )
+        .map((application) => application.name)
+        .sort()
+        .join(","),
+    // cacheVersion の変化でしか deploying 集合は変わらないため、cacheVersion を依存に含める
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [applications, cacheVersion]
+  );
+
   useEffect(() => {
-    if (
-      !selectedApplicationConfig ||
-      displayApplicationStatus !== "Deploying"
-    ) {
+    if (!deployingApplicationNames) {
       return;
     }
 
-    loadApplication(selectedApplicationConfig, { force: true });
+    const deployingNameSet = new Set(deployingApplicationNames.split(","));
+    const deployingApplications = applications.filter((application) =>
+      deployingNameSet.has(application.name)
+    );
+
     const intervalId = window.setInterval(() => {
-      loadApplication(selectedApplicationConfig, { force: true });
+      for (const application of deployingApplications) {
+        loadApplication(application, { force: true });
+      }
     }, DEPLOYMENT_POLLING_INTERVAL_MS);
 
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [displayApplicationStatus, loadApplication, selectedApplicationConfig]);
+  }, [applications, deployingApplicationNames, loadApplication]);
 
   const handleApplicationChanged = useCallback(
     (name: string) => {
@@ -310,6 +346,8 @@ export function ApplicationDashboard({
                   );
                   const cachedApplication = getCachedApplication(application);
                   const displayApplication = cachedApplication || application;
+                  const hasActiveDeployment =
+                    getApplicationStatus(displayApplication).status === "Deploying";
 
                   return (
                     <div
@@ -333,6 +371,7 @@ export function ApplicationDashboard({
                       </Link>
                       <DashboardEditApplicationButton
                         application={application}
+                        hasActiveDeployment={hasActiveDeployment}
                         onApplicationChanged={handleApplicationChanged}
                         onApplicationDeleted={handleApplicationDeleted}
                       />

--- a/ecscd/src/components/dashboard/edit-application-button.tsx
+++ b/ecscd/src/components/dashboard/edit-application-button.tsx
@@ -9,10 +9,12 @@ import { ApplicationDomain } from "@/lib/domain/application";
 
 export function DashboardEditApplicationButton({
   application,
+  hasActiveDeployment,
   onApplicationChanged,
   onApplicationDeleted,
 }: {
   application: ApplicationDomain;
+  hasActiveDeployment: boolean;
   onApplicationChanged: (name: string) => void;
   onApplicationDeleted: (name: string) => void;
 }) {
@@ -53,6 +55,7 @@ export function DashboardEditApplicationButton({
       <Button
         variant="ghost"
         size="icon"
+        disabled={hasActiveDeployment}
         onClick={(event) => {
           event.stopPropagation();
           setIsOpen(true);
@@ -65,6 +68,7 @@ export function DashboardEditApplicationButton({
         open={isOpen}
         onOpenChange={setIsOpen}
         application={application}
+        hasActiveDeployment={hasActiveDeployment}
         onSuccess={() => onApplicationChanged(application.name)}
         onDelete={handleDelete}
       />

--- a/ecscd/src/components/dashboard/last-deployment.tsx
+++ b/ecscd/src/components/dashboard/last-deployment.tsx
@@ -7,7 +7,7 @@ import {
 import { formatRelativeTime } from "@/components/dashboard/format";
 import { ExternalLink, RefreshCw } from "lucide-react";
 
-function formatDeploymentState(state: string) {
+function formatDeploymentState(state: string | undefined) {
   switch (state) {
     case "IN_PROGRESS":
       return "In Progress";
@@ -16,11 +16,11 @@ function formatDeploymentState(state: string) {
     case "FAILED":
       return "Failed";
     default:
-      return state;
+      return state || "Unknown";
   }
 }
 
-function getDeploymentStateClass(state: string) {
+function getDeploymentStateClass(state: string | undefined) {
   switch (state) {
     case "IN_PROGRESS":
       return "text-yellow-600 dark:text-yellow-400";

--- a/ecscd/src/lib/di.ts
+++ b/ecscd/src/lib/di.ts
@@ -32,7 +32,7 @@ const aws = new AWS();
 const ar = new Application(db);
 const dr = new Deployment(
   aws,
-  new GitHub(process.env.GITHUB_TOKEN || "")
+  new GitHub(process.env.GITHUB_TOKEN || "", process.env.GITHUB_API_URL)
 );
 const observer = new DefaultApplicationObserver(
   new AwsServiceStateProvider(aws),

--- a/ecscd/src/lib/di.ts
+++ b/ecscd/src/lib/di.ts
@@ -41,5 +41,5 @@ const observer = new DefaultApplicationObserver(
 const fr = new Filter(db);
 
 export const au: IApplicationUsecase = new ApplicationUsecase(ar, observer);
-export const du = new DeploymentUsecase(dr);
+export const du = new DeploymentUsecase(dr, ar);
 export const fu = new FilterUsecase(fr);

--- a/ecscd/src/lib/domain/application.ts
+++ b/ecscd/src/lib/domain/application.ts
@@ -44,6 +44,7 @@ export interface ApplicationDomain {
   awsConfig: AwsAccessProfile;
   createdAt: Date;
   updatedAt: Date;
+  lastSyncedAt?: Date;
 }
 
 export interface ObservedApplicationDomain extends ApplicationDomain {
@@ -134,7 +135,7 @@ export interface ServiceDomain {
     status: EcsDeploymentStatus;
     createdAt: Date;
     updatedAt: Date;
-    rolloutState: EcsRolloutState;
+    rolloutState?: EcsRolloutState;
     rolloutStateReason: string;
   }[];
 }
@@ -192,6 +193,28 @@ export function getApplicationStatus(
 
   const service = application.service.value;
 
+  // デプロイ中 (IN_PROGRESS) かどうかは GitHub 側の一時エラー (レートリミット等) より
+  // 優先して判定する。そうしないと、デプロイ中に sync/diff の取得が 1 回失敗しただけで
+  // "Deploying" → "Error" に反転し、UI の Deploying 限定ポーリング
+  // (application-dashboard.tsx の polling effect) が恒久的に止まってしまう。
+  const currentDeployment = getApplicationCurrentDeployment(application);
+
+  if (currentDeployment?.rolloutState === "IN_PROGRESS") {
+    return {
+      status: "Deploying",
+      reason:
+        currentDeployment.rolloutStateReason || "Deployment is in progress.",
+    };
+  }
+
+  if (currentDeployment?.rolloutState === "FAILED") {
+    return {
+      status: "Failed",
+      reason:
+        currentDeployment.rolloutStateReason || "The last deployment failed.",
+    };
+  }
+
   if (application.sync.status === "Error") {
     return {
       status: "Error",
@@ -215,24 +238,6 @@ export function getApplicationStatus(
     return {
       status: "Error",
       reason: `ECS service is ${service.status}. ecscd requires an ACTIVE service.`,
-    };
-  }
-
-  const currentDeployment = getApplicationCurrentDeployment(application);
-
-  if (currentDeployment?.rolloutState === "IN_PROGRESS") {
-    return {
-      status: "Deploying",
-      reason:
-        currentDeployment.rolloutStateReason || "Deployment is in progress.",
-    };
-  }
-
-  if (currentDeployment?.rolloutState === "FAILED") {
-    return {
-      status: "Failed",
-      reason:
-        currentDeployment.rolloutStateReason || "The last deployment failed.",
     };
   }
 

--- a/ecscd/src/lib/infrastructure/application.ts
+++ b/ecscd/src/lib/infrastructure/application.ts
@@ -30,4 +30,7 @@ export class Application implements ApplicationRepository {
   async deleteApplication(name: string): Promise<void> {
     await this.db.deleteApplication(name);
   }
+  async updateLastSyncedAt(name: string, syncedAt: Date): Promise<void> {
+    await this.db.updateLastSyncedAt(name, syncedAt);
+  }
 }

--- a/ecscd/src/lib/infrastructure/aws.ts
+++ b/ecscd/src/lib/infrastructure/aws.ts
@@ -27,14 +27,7 @@ import {
   STSClientConfig,
 } from "@aws-sdk/client-sts";
 
-function normalizeRolloutStateReason(
-  rolloutState: string | undefined,
-  reason: string | undefined
-) {
-  if (rolloutState !== "FAILED") {
-    return "";
-  }
-
+function normalizeRolloutStateReason(reason: string | undefined) {
   return reason?.trim() || "";
 }
 
@@ -54,7 +47,9 @@ function toEcsDeploymentStatus(status: string | undefined): EcsDeploymentStatus 
   return "INACTIVE";
 }
 
-function toEcsRolloutState(status: string | undefined): EcsRolloutState {
+function toEcsRolloutState(
+  status: string | undefined,
+): EcsRolloutState | undefined {
   if (
     status === "COMPLETED" ||
     status === "FAILED" ||
@@ -63,7 +58,11 @@ function toEcsRolloutState(status: string | undefined): EcsRolloutState {
     return status;
   }
 
-  return "FAILED";
+  // rolloutState を返さない CODE_DEPLOY / EXTERNAL デプロイメントコントローラの
+  // サービスでは undefined を透過する。ここで "FAILED" 扱いにすると、
+  // getApplicationStatus が恒久的に "Failed" を表示してしまうため、
+  // IN_PROGRESS / FAILED 判定をスキップさせて sync 由来の状態にフォールバックさせる。
+  return undefined;
 }
 
 function toRegisterTaskDefinitionInput(
@@ -144,10 +143,7 @@ export class AWS implements IAws {
       deployments: (response.services?.[0]?.deployments || []).map((d) => ({
         status: toEcsDeploymentStatus(d.status),
         rolloutState: toEcsRolloutState(d.rolloutState),
-        rolloutStateReason: normalizeRolloutStateReason(
-          d.rolloutState,
-          d.rolloutStateReason
-        ),
+        rolloutStateReason: normalizeRolloutStateReason(d.rolloutStateReason),
         createdAt: d.createdAt || new Date(),
         updatedAt: d.updatedAt || new Date(),
       })),

--- a/ecscd/src/lib/infrastructure/dynamodb.ts
+++ b/ecscd/src/lib/infrastructure/dynamodb.ts
@@ -24,6 +24,7 @@ interface ApplicationsModel {
   aws_external_id: string;
   created_at: string;
   updated_at: string;
+  last_synced_at?: string;
 }
 
 interface FiltersModel {
@@ -48,9 +49,12 @@ export class DynamoDB implements IDatabase {
 
   async getApplications(): Promise<ApplicationDomain[]> {
     try {
+      // item_type 属性が無い既存アイテムは item_type 導入前 (main) に書き込まれた
+      // アプリケーション行なので、フィルタなしと同じ扱いにする
+      // (filter アイテムは item_type="filter" を必ず持つため、属性なし = 旧アプリ行)。
       const command = new ScanCommand({
         TableName: this.tableName,
-        FilterExpression: "item_type = :item_type",
+        FilterExpression: "attribute_not_exists(item_type) OR item_type = :item_type",
         ExpressionAttributeValues: {
           ":item_type": "application",
         },
@@ -78,7 +82,7 @@ export class DynamoDB implements IDatabase {
     try {
       const command = new ScanCommand({
         TableName: this.tableName,
-        FilterExpression: "item_type = :item_type",
+        FilterExpression: "attribute_not_exists(item_type) OR item_type = :item_type",
         ExpressionAttributeValues: {
           ":item_type": "application",
         },
@@ -236,7 +240,37 @@ export class DynamoDB implements IDatabase {
       },
       createdAt: new Date(item.created_at),
       updatedAt: new Date(item.updated_at),
+      lastSyncedAt: item.last_synced_at ? new Date(item.last_synced_at) : undefined,
     };
+  }
+
+  async updateLastSyncedAt(name: string, syncedAt: Date): Promise<void> {
+    try {
+      const command = new UpdateCommand({
+        TableName: this.tableName,
+        Key: {
+          name,
+        },
+        UpdateExpression: "SET last_synced_at = :last_synced_at",
+        ExpressionAttributeValues: {
+          ":last_synced_at": syncedAt.toISOString(),
+        },
+        ConditionExpression: "attribute_exists(#name)",
+        ExpressionAttributeNames: {
+          "#name": "name",
+        },
+      });
+
+      await this.client.send(command);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === "ConditionalCheckFailedException"
+      ) {
+        throw new Error(`Application with name '${name}' does not exist`);
+      }
+      throw new Error(`Failed to update last synced at: ${error}`);
+    }
   }
 
   async getFilters(): Promise<FilterDomain[]> {

--- a/ecscd/src/lib/infrastructure/github.ts
+++ b/ecscd/src/lib/infrastructure/github.ts
@@ -9,6 +9,8 @@ import { toTaskDefinitionSpec } from "./task-definition-normalizer";
 export class GitHub implements IGithub {
   private octokit: Octokit;
 
+  // baseUrl は GitHub API エンドポイントの差し替え用 (ローカル検証用スタブや
+  // GitHub Enterprise Server など)。未指定なら api.github.com。
   constructor(token: string, baseUrl?: string) {
     this.octokit = new Octokit({
       auth: token,

--- a/ecscd/src/lib/infrastructure/github.ts
+++ b/ecscd/src/lib/infrastructure/github.ts
@@ -9,9 +9,10 @@ import { toTaskDefinitionSpec } from "./task-definition-normalizer";
 export class GitHub implements IGithub {
   private octokit: Octokit;
 
-  constructor(token: string) {
+  constructor(token: string, baseUrl?: string) {
     this.octokit = new Octokit({
       auth: token,
+      ...(baseUrl ? { baseUrl } : {}),
     });
   }
 

--- a/ecscd/src/lib/infrastructure/interface/database.ts
+++ b/ecscd/src/lib/infrastructure/interface/database.ts
@@ -7,6 +7,7 @@ export interface IDatabase {
   createApplication(application: ApplicationDomain): Promise<void>;
   updateApplication(application: ApplicationDomain): Promise<void>;
   deleteApplication(name: string): Promise<void>;
+  updateLastSyncedAt(name: string, syncedAt: Date): Promise<void>;
 
   getFilters(): Promise<FilterDomain[]>;
   getFilterById(id: string): Promise<FilterDomain | null>;

--- a/ecscd/src/lib/infrastructure/sqlite.ts
+++ b/ecscd/src/lib/infrastructure/sqlite.ts
@@ -17,6 +17,7 @@ interface ApplicationsModel {
   aws_external_id: string;
   created_at: string;
   updated_at: string;
+  last_synced_at: string | null;
 }
 
 interface FiltersModel {
@@ -40,7 +41,10 @@ export class SQLite implements IDatabase {
     this.initializeDatabase();
   }
   private async initializeDatabase(): Promise<void> {
-    // Initialize SQLite database connection and create tables if they don't exist
+    // Initialize SQLite database connection and create tables if they don't exist.
+    // 両方の CREATE を serialize() 内で同期的に enqueue することで、コンストラクタが
+    // initializeDatabase() を await しなくても、以降にキューへ入る他のクエリ (SELECT 等)
+    // より必ず先に実行される。
     return new Promise((resolve, reject) => {
       this.db.serialize(() => {
         this.db.run(
@@ -56,32 +60,41 @@ export class SQLite implements IDatabase {
                 aws_role_arn TEXT,
                 aws_external_id TEXT NOT NULL,
                 created_at DATETIME NOT NULL,
-                updated_at DATETIME NOT NULL
+                updated_at DATETIME NOT NULL,
+                last_synced_at DATETIME
             )`,
           (err: Error | null) => {
             if (err) {
               reject(err);
+            }
+          },
+        );
+
+        // last_synced_at は既存 DB に後から追加したカラムなので、旧テーブルには
+        // ALTER TABLE で補う。既に存在する場合のエラー (duplicate column name) は無視する。
+        this.db.run(
+          `ALTER TABLE applications ADD COLUMN last_synced_at DATETIME`,
+          () => {
+            // 追加済みなら SQLITE_ERROR (duplicate column name) になるだけなので無視する
+          },
+        );
+
+        this.db.run(
+          `
+            CREATE TABLE IF NOT EXISTS filters (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                pattern TEXT NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )`,
+          (filterErr: Error | null) => {
+            if (filterErr) {
+              reject(filterErr);
               return;
             }
 
-            this.db.run(
-              `
-                CREATE TABLE IF NOT EXISTS filters (
-                    id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    pattern TEXT NOT NULL,
-                    created_at DATETIME NOT NULL,
-                    updated_at DATETIME NOT NULL
-                )`,
-              (filterErr: Error | null) => {
-                if (filterErr) {
-                  reject(filterErr);
-                  return;
-                }
-
-                resolve();
-              },
-            );
+            resolve();
           },
         );
       });
@@ -224,7 +237,23 @@ export class SQLite implements IDatabase {
       },
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
+      lastSyncedAt: row.last_synced_at ? new Date(row.last_synced_at) : undefined,
     };
+  }
+
+  async updateLastSyncedAt(name: string, syncedAt: Date): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.db.run(
+        `UPDATE applications SET last_synced_at = ? WHERE name = ?`,
+        [syncedAt.toISOString(), name],
+        (err: Error | null) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve();
+        },
+      );
+    });
   }
 
   async getFilters(): Promise<FilterDomain[]> {

--- a/ecscd/src/lib/repository/application.ts
+++ b/ecscd/src/lib/repository/application.ts
@@ -7,4 +7,5 @@ export interface ApplicationRepository {
   createApplication(application: ApplicationDomain): Promise<void>;
   updateApplication(application: ApplicationDomain): Promise<void>;
   deleteApplication(name: string): Promise<void>;
+  updateLastSyncedAt(name: string, syncedAt: Date): Promise<void>;
 }

--- a/ecscd/src/lib/usecase/application-observer.ts
+++ b/ecscd/src/lib/usecase/application-observer.ts
@@ -53,10 +53,9 @@ export class DefaultApplicationObserver implements ApplicationObserver {
       return serviceObservedApplication;
     }
 
-    const lastSyncedAt =
-      serviceObservedApplication.sync.status === "Success"
-        ? serviceObservedApplication.sync.value?.lastSyncedAt
-        : undefined;
+    // 最終 Sync 時刻は DB に永続化された値をそのまま使う (sync 実行時に
+    // DeploymentUsecase.syncService が更新する。usecase/deployment.ts 参照)。
+    const lastSyncedAt = application.lastSyncedAt;
 
     try {
       const taskDefinitions =

--- a/ecscd/src/lib/usecase/deployment.ts
+++ b/ecscd/src/lib/usecase/deployment.ts
@@ -1,4 +1,5 @@
 import { ApplicationDomain } from "../domain/application";
+import { ApplicationRepository } from "../repository/application";
 import { DeploymentRepository } from "../repository/deployment";
 export interface IDeploymentUsecase {
   syncService(application: ApplicationDomain): Promise<void>;
@@ -7,12 +8,21 @@ export interface IDeploymentUsecase {
 
 export class DeploymentUsecase {
   private deploymentRepository: DeploymentRepository;
-  constructor(deploymentRepository: DeploymentRepository) {
+  private applicationRepository: ApplicationRepository;
+  constructor(
+    deploymentRepository: DeploymentRepository,
+    applicationRepository: ApplicationRepository,
+  ) {
     this.deploymentRepository = deploymentRepository;
+    this.applicationRepository = applicationRepository;
   }
 
   async syncService(application: ApplicationDomain): Promise<void> {
     await this.deploymentRepository.syncService(application);
+    await this.applicationRepository.updateLastSyncedAt(
+      application.name,
+      new Date(),
+    );
   }
 
   async rollback(application: ApplicationDomain): Promise<void> {

--- a/ecscd/tests/integration/dynamodb.test.ts
+++ b/ecscd/tests/integration/dynamodb.test.ts
@@ -1,0 +1,129 @@
+/**
+ * DynamoDB リポジトリ実装を ministack の DynamoDB に対して検証する統合テスト。
+ * テスト対象 (src/lib/infrastructure/dynamodb.ts) は endpoint を明示しないため、
+ * AWS_ENDPOINT_URL 環境変数の解決を含めて本番同等の経路を通る。
+ */
+import { describe, beforeAll, expect, it } from "@jest/globals";
+import { DynamoDB } from "../../src/lib/infrastructure/dynamodb";
+import { FilterDomain } from "../../src/lib/domain/filter";
+import {
+  REGION,
+  buildApplication,
+  createApplicationsTable,
+  rawDynamoDbClient,
+  uniqueName,
+  waitForMinistack,
+} from "./helpers";
+
+describe("DynamoDB repository (ministack)", () => {
+  const tableName = uniqueName("ecscd-it");
+  let db: DynamoDB;
+
+  beforeAll(async () => {
+    await waitForMinistack();
+    await createApplicationsTable(rawDynamoDbClient(), tableName);
+    db = new DynamoDB(REGION, tableName);
+  });
+
+  it("creates and lists an application", async () => {
+    const app = buildApplication({
+      name: uniqueName("app"),
+      cluster: "c1",
+      service: "s1",
+    });
+
+    await db.createApplication(app);
+
+    const applications = await db.getApplications();
+    const found = applications.find((a) => a.name === app.name);
+    expect(found).toBeDefined();
+    expect(found?.gitConfig).toEqual(app.gitConfig);
+    expect(found?.ecsConfig).toEqual(app.ecsConfig);
+
+    const names = await db.getApplicationNames();
+    expect(names).toContain(app.name);
+  });
+
+  it("updates an application", async () => {
+    const app = buildApplication({
+      name: uniqueName("app"),
+      cluster: "c1",
+      service: "s1",
+    });
+    await db.createApplication(app);
+
+    await db.updateApplication({
+      ...app,
+      gitConfig: { ...app.gitConfig, branch: "develop" },
+      updatedAt: new Date(),
+    });
+
+    const applications = await db.getApplications();
+    const found = applications.find((a) => a.name === app.name);
+    expect(found?.gitConfig.branch).toBe("develop");
+  });
+
+  it("deletes an application", async () => {
+    const app = buildApplication({
+      name: uniqueName("app"),
+      cluster: "c1",
+      service: "s1",
+    });
+    await db.createApplication(app);
+
+    await db.deleteApplication(app.name);
+
+    const names = await db.getApplicationNames();
+    expect(names).not.toContain(app.name);
+  });
+
+  it("rejects duplicate application names", async () => {
+    const app = buildApplication({
+      name: uniqueName("app"),
+      cluster: "c1",
+      service: "s1",
+    });
+    await db.createApplication(app);
+
+    await expect(db.createApplication(app)).rejects.toThrow(/already exists/);
+  });
+
+  it("filters CRUD round-trip", async () => {
+    const now = new Date();
+    const filter: FilterDomain = {
+      id: uniqueName("filter"),
+      name: "backend services",
+      pattern: "backend",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await db.createFilter(filter);
+
+    const filters = await db.getFilters();
+    const found = filters.find((f) => f.id === filter.id);
+    expect(found?.name).toBe(filter.name);
+    expect(found?.pattern).toBe(filter.pattern);
+
+    const byId = await db.getFilterById(filter.id);
+    expect(byId?.pattern).toBe(filter.pattern);
+
+    await db.deleteFilter(filter.id);
+    expect(await db.getFilterById(filter.id)).toBeNull();
+  });
+
+  it("filter items do not leak into application listings", async () => {
+    const now = new Date();
+    const filter: FilterDomain = {
+      id: uniqueName("filter"),
+      name: "leak-check",
+      pattern: "x",
+      createdAt: now,
+      updatedAt: now,
+    };
+    await db.createFilter(filter);
+
+    const names = await db.getApplicationNames();
+    expect(names.find((n) => n.startsWith("filter#"))).toBeUndefined();
+  });
+});

--- a/ecscd/tests/integration/ecs.test.ts
+++ b/ecscd/tests/integration/ecs.test.ts
@@ -1,5 +1,5 @@
 /**
- * AWS (ECS) インフラ実装を ministack の ECS API に対して検証する統合テスト。
+ * AWS (ECS) インフラ実装を ecs-sim の ECS API に対して検証する統合テスト。
  * registerTaskDefinition → describeTaskDefinition の正規化 (AWS 付与フィールドの除去)、
  * describeServices / updateService の一連の流れを本物の API 呼び出しで確認する。
  */
@@ -18,7 +18,7 @@ import {
 
 const awsConfig = { region: REGION, roleArn: "", externalId: "integration-test" };
 
-describe("AWS(ECS) repository (ministack)", () => {
+describe("AWS(ECS) repository (ecs-sim)", () => {
   const aws = new AWS();
   const family = uniqueName("td");
   const cluster = uniqueName("cluster");

--- a/ecscd/tests/integration/ecs.test.ts
+++ b/ecscd/tests/integration/ecs.test.ts
@@ -1,0 +1,105 @@
+/**
+ * AWS (ECS) インフラ実装を ministack の ECS API に対して検証する統合テスト。
+ * registerTaskDefinition → describeTaskDefinition の正規化 (AWS 付与フィールドの除去)、
+ * describeServices / updateService の一連の流れを本物の API 呼び出しで確認する。
+ */
+import { describe, beforeAll, expect, it } from "@jest/globals";
+import { AWS } from "../../src/lib/infrastructure/aws";
+import { TaskDefinitionSpec } from "../../src/lib/domain/task-definition";
+import {
+  BASE_TASK_DEFINITION,
+  REGION,
+  createClusterAndService,
+  rawEcsClient,
+  uniqueName,
+  waitForEcsSim,
+  waitForMinistack,
+} from "./helpers";
+
+const awsConfig = { region: REGION, roleArn: "", externalId: "integration-test" };
+
+describe("AWS(ECS) repository (ministack)", () => {
+  const aws = new AWS();
+  const family = uniqueName("td");
+  const cluster = uniqueName("cluster");
+  const service = uniqueName("service");
+  let initialArn: string;
+
+  const spec = (extraEnv?: { name: string; value: string }): TaskDefinitionSpec =>
+    ({
+      ...BASE_TASK_DEFINITION,
+      family,
+      containerDefinitions: [
+        {
+          ...BASE_TASK_DEFINITION.containerDefinitions[0],
+          ...(extraEnv ? { environment: [extraEnv] } : {}),
+        },
+      ],
+    }) as TaskDefinitionSpec;
+
+  beforeAll(async () => {
+    await waitForMinistack();
+    await waitForEcsSim();
+    initialArn = await aws.registerTaskDefinition(awsConfig, spec());
+    await createClusterAndService(rawEcsClient(), cluster, service, initialArn);
+  });
+
+  it("registerTaskDefinition returns a task definition ARN", () => {
+    expect(initialArn).toMatch(/^arn:aws:ecs:/);
+    expect(initialArn).toContain(family);
+  });
+
+  it("describeTaskDefinition returns the normalized spec (AWS-generated fields stripped)", async () => {
+    const described = await aws.describeTaskDefinition(awsConfig, initialArn);
+
+    expect(described).toBeDefined();
+    expect(described?.family).toBe(family);
+
+    const containers = described?.containerDefinitions as
+      | Array<Record<string, unknown>>
+      | undefined;
+    expect(containers?.[0]?.image).toBe("busybox:latest");
+
+    // task-definition-normalizer が AWS 付与フィールドを剥がしていること
+    // (剥がれていないと compareTaskDefinitions が常に OutOfSync になる)
+    expect(described).not.toHaveProperty("taskDefinitionArn");
+    expect(described).not.toHaveProperty("revision");
+    expect(described).not.toHaveProperty("status");
+    expect(described).not.toHaveProperty("registeredAt");
+  });
+
+  it("describeServices returns the service with its current task definition", async () => {
+    const described = await aws.describeServices(awsConfig, {
+      cluster,
+      service,
+    });
+
+    expect(described).toBeDefined();
+    expect(described?.taskDefinition).toBe(initialArn);
+    expect(described?.status).toBe("ACTIVE");
+  });
+
+  it("updateService points the service at a new revision", async () => {
+    const nextArn = await aws.registerTaskDefinition(
+      awsConfig,
+      spec({ name: "DEPLOYED_FROM", value: "integration-test" })
+    );
+    expect(nextArn).not.toBe(initialArn);
+
+    await aws.updateService(awsConfig, { cluster, service }, nextArn);
+
+    const described = await aws.describeServices(awsConfig, {
+      cluster,
+      service,
+    });
+    expect(described?.taskDefinition).toBe(nextArn);
+  });
+
+  it("describeServices returns undefined for a missing service", async () => {
+    const described = await aws.describeServices(awsConfig, {
+      cluster,
+      service: "no-such-service",
+    });
+    expect(described).toBeUndefined();
+  });
+});

--- a/ecscd/tests/integration/helpers.ts
+++ b/ecscd/tests/integration/helpers.ts
@@ -1,0 +1,176 @@
+import {
+  CreateTableCommand,
+  DescribeTableCommand,
+  DynamoDBClient,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CreateClusterCommand,
+  CreateServiceCommand,
+  ListClustersCommand,
+  ECSClient,
+} from "@aws-sdk/client-ecs";
+import { GetCallerIdentityCommand, STSClient } from "@aws-sdk/client-sts";
+import { ApplicationDomain } from "../../src/lib/domain/application";
+
+export const ENDPOINT = process.env.AWS_ENDPOINT_URL!;
+// ECS だけ ecs-sim (実際の ECS のような非同期ロールアウトを再現する) に向ける。
+// 本番コードは AWS_ENDPOINT_URL_ECS を SDK が自動的に読むため未指定でも動くが、
+// テストのセットアップ用 raw クライアントは明示的に指定する。
+export const ECS_ENDPOINT =
+  process.env.AWS_ENDPOINT_URL_ECS || process.env.AWS_ENDPOINT_URL!;
+export const REGION = process.env.AWS_REGION || "us-east-1";
+
+// テスト間・デモ環境との衝突を避けるため、リソース名は毎回ユニークにする
+// (ministack のリセットは不要になり、動作確認用スタックと同居できる)。
+export function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ministack が受け付け可能になるまで待つ (compose の init と同じ判定)
+export async function waitForMinistack(timeoutMs = 60_000): Promise<void> {
+  const sts = new STSClient({ region: REGION, endpoint: ENDPOINT });
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await sts.send(new GetCallerIdentityCommand({}));
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+  }
+  throw new Error(
+    `ministack (${ENDPOINT}) not reachable: ${
+      lastError instanceof Error ? lastError.message : lastError
+    }`
+  );
+}
+
+// ecs-sim が受け付け可能になるまで待つ (compose の init と同じ判定)
+export async function waitForEcsSim(timeoutMs = 60_000): Promise<void> {
+  const ecs = rawEcsClient();
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await ecs.send(new ListClustersCommand({}));
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+  }
+  throw new Error(
+    `ecs-sim (${ECS_ENDPOINT}) not reachable: ${
+      lastError instanceof Error ? lastError.message : lastError
+    }`
+  );
+}
+
+// テストのセットアップ用 raw クライアント。テスト対象のプロダクションコードは
+// endpoint を明示せず環境変数 AWS_ENDPOINT_URL 経由で解決するのに対し、こちらは
+// 明示指定してセットアップ自体の失敗要因を切り分ける。
+export function rawDynamoDbClient(): DynamoDBClient {
+  return new DynamoDBClient({ region: REGION, endpoint: ENDPOINT });
+}
+
+export function rawEcsClient(): ECSClient {
+  return new ECSClient({ region: REGION, endpoint: ECS_ENDPOINT });
+}
+
+export async function createApplicationsTable(
+  client: DynamoDBClient,
+  tableName: string
+): Promise<void> {
+  await client.send(
+    new CreateTableCommand({
+      TableName: tableName,
+      AttributeDefinitions: [{ AttributeName: "name", AttributeType: "S" }],
+      KeySchema: [{ AttributeName: "name", KeyType: "HASH" }],
+      BillingMode: "PAY_PER_REQUEST",
+    })
+  );
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const described = await client.send(
+      new DescribeTableCommand({ TableName: tableName })
+    );
+    if (described.Table?.TableStatus === "ACTIVE") {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`table ${tableName} did not become ACTIVE`);
+}
+
+export async function createClusterAndService(
+  client: ECSClient,
+  cluster: string,
+  service: string,
+  taskDefinitionArn: string
+): Promise<void> {
+  await client.send(new CreateClusterCommand({ clusterName: cluster }));
+  await client.send(
+    new CreateServiceCommand({
+      cluster,
+      serviceName: service,
+      taskDefinition: taskDefinitionArn,
+      desiredCount: 1,
+    })
+  );
+}
+
+export function buildApplication(overrides: {
+  name: string;
+  cluster: string;
+  service: string;
+  repo?: string;
+  branch?: string;
+  path?: string;
+}): ApplicationDomain {
+  const now = new Date();
+  return {
+    name: overrides.name,
+    gitConfig: {
+      repo: overrides.repo ?? "https://github.com/demo/app",
+      branch: overrides.branch ?? "main",
+      path: overrides.path ?? "task-definition.json",
+    },
+    ecsConfig: {
+      cluster: overrides.cluster,
+      service: overrides.service,
+    },
+    // roleArn を空にすると STS AssumeRole を経由せず環境変数の認証情報が使われる
+    awsConfig: { region: REGION, roleArn: "", externalId: "integration-test" },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// DescribeTaskDefinition はサーバ側デフォルト (タスクレベル cpu/memory、空文字の
+// taskRoleArn 等、コンテナレベル cpu: 0) を補完して返すため、Git 側 (=target) が
+// それらを省略していると幻の "Removed" diff が出て OutOfSync になる。
+// テストでは両辺を一致させるためデフォルト値まで明示した完全形を使う。
+// (実 AWS でもコンテナ cpu: 0 などは補完されるため、この挙動は本番でも起こり得る)
+export const BASE_TASK_DEFINITION = {
+  family: "integration-demo",
+  networkMode: "bridge",
+  requiresCompatibilities: ["EC2"],
+  taskRoleArn: "",
+  executionRoleArn: "",
+  cpu: "256",
+  memory: "512",
+  pidMode: "",
+  ipcMode: "",
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "busybox:latest",
+      command: ["sleep", "3600"],
+      cpu: 0,
+      memory: 64,
+      essential: true,
+    },
+  ],
+};

--- a/ecscd/tests/integration/observe.test.ts
+++ b/ecscd/tests/integration/observe.test.ts
@@ -46,7 +46,7 @@ describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () =>
 
   // スタブが返す「Git 上の望ましいタスク定義」。テスト中に差し替える。
   let gitTaskDefinition = taskDefinitionJson();
-  let stubServer: http.Server;
+  let stubServer: http.Server | undefined;
 
   const aws = new AWS();
   let observer: DefaultApplicationObserver;
@@ -62,7 +62,7 @@ describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () =>
     await waitForMinistack();
     await waitForEcsSim();
 
-    stubServer = http.createServer((req, res) => {
+    const server = http.createServer((req, res) => {
       const url = new URL(req.url || "/", "http://localhost");
       const json = (status: number, body: unknown) => {
         res.writeHead(status, { "Content-Type": "application/json" });
@@ -82,8 +82,9 @@ describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () =>
       }
       json(404, { message: "Not Found" });
     });
-    await new Promise<void>((resolve) => stubServer.listen(0, resolve));
-    const port = (stubServer.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    stubServer = server;
+    const port = (server.address() as AddressInfo).port;
 
     const github = new GitHub("dummy-token", `http://127.0.0.1:${port}`);
     deployment = new Deployment(aws, github);
@@ -100,8 +101,13 @@ describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () =>
   });
 
   afterAll(async () => {
+    // beforeAll が途中で失敗すると stubServer が未初期化のままここに来るので、
+    // その場合は close を呼ばず (元の失敗原因を隠さないよう) 何もしない。
+    if (!stubServer) {
+      return;
+    }
     await new Promise<void>((resolve, reject) =>
-      stubServer.close((err) => (err ? reject(err) : resolve()))
+      stubServer!.close((err) => (err ? reject(err) : resolve()))
     );
   });
 

--- a/ecscd/tests/integration/observe.test.ts
+++ b/ecscd/tests/integration/observe.test.ts
@@ -94,7 +94,7 @@ describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () =>
 
     const initialArn = await aws.registerTaskDefinition(
       application.awsConfig,
-      taskDefinitionJson() as never
+      taskDefinitionJson()
     );
     await createClusterAndService(rawEcsClient(), cluster, service, initialArn);
   });

--- a/ecscd/tests/integration/observe.test.ts
+++ b/ecscd/tests/integration/observe.test.ts
@@ -1,6 +1,7 @@
 /**
  * observe → sync のエンドツーエンド統合テスト。
- * ECS 側は ministack、GitHub 側はテストプロセス内に立てたスタブ HTTP サーバを使い、
+ * ECS 側は ecs-sim (DynamoDB/STS は ministack)、GitHub 側はテストプロセス内に
+ * 立てたスタブ HTTP サーバを使い、
  * GitHub(baseUrl) / Deployment / AwsServiceStateProvider / DefaultApplicationObserver を
  * 本物のワイヤリングで通す:
  *   Git とタスク定義が一致       -> InSync
@@ -40,7 +41,7 @@ function taskDefinitionJson(extraEnv?: { name: string; value: string }) {
   };
 }
 
-describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () => {
+describe("observe & sync end-to-end (ecs-sim/ministack + in-process GitHub stub)", () => {
   const cluster = uniqueName("cluster");
   const service = uniqueName("service");
 

--- a/ecscd/tests/integration/observe.test.ts
+++ b/ecscd/tests/integration/observe.test.ts
@@ -1,0 +1,168 @@
+/**
+ * observe → sync のエンドツーエンド統合テスト。
+ * ECS 側は ministack、GitHub 側はテストプロセス内に立てたスタブ HTTP サーバを使い、
+ * GitHub(baseUrl) / Deployment / AwsServiceStateProvider / DefaultApplicationObserver を
+ * 本物のワイヤリングで通す:
+ *   Git とタスク定義が一致       -> InSync
+ *   Git 側にだけ環境変数を追加   -> OutOfSync (+ diff)
+ *   syncService 実行             -> 新リビジョンがサービスに反映され InSync に戻る
+ */
+import { describe, afterAll, beforeAll, expect, it } from "@jest/globals";
+import * as http from "http";
+import { AddressInfo } from "net";
+import { AWS } from "../../src/lib/infrastructure/aws";
+import { Deployment } from "../../src/lib/infrastructure/deployment";
+import { GitHub } from "../../src/lib/infrastructure/github";
+import { AwsServiceStateProvider } from "../../src/lib/infrastructure/service-state-provider";
+import { DefaultApplicationObserver } from "../../src/lib/usecase/application-observer";
+import {
+  BASE_TASK_DEFINITION,
+  buildApplication,
+  createClusterAndService,
+  rawEcsClient,
+  uniqueName,
+  waitForEcsSim,
+  waitForMinistack,
+} from "./helpers";
+
+const family = uniqueName("td");
+
+function taskDefinitionJson(extraEnv?: { name: string; value: string }) {
+  return {
+    ...BASE_TASK_DEFINITION,
+    family,
+    containerDefinitions: [
+      {
+        ...BASE_TASK_DEFINITION.containerDefinitions[0],
+        ...(extraEnv ? { environment: [extraEnv] } : {}),
+      },
+    ],
+  };
+}
+
+describe("observe & sync end-to-end (ministack + in-process GitHub stub)", () => {
+  const cluster = uniqueName("cluster");
+  const service = uniqueName("service");
+
+  // スタブが返す「Git 上の望ましいタスク定義」。テスト中に差し替える。
+  let gitTaskDefinition = taskDefinitionJson();
+  let stubServer: http.Server;
+
+  const aws = new AWS();
+  let observer: DefaultApplicationObserver;
+  let deployment: Deployment;
+
+  const application = buildApplication({
+    name: uniqueName("app"),
+    cluster,
+    service,
+  });
+
+  beforeAll(async () => {
+    await waitForMinistack();
+    await waitForEcsSim();
+
+    stubServer = http.createServer((req, res) => {
+      const url = new URL(req.url || "/", "http://localhost");
+      const json = (status: number, body: unknown) => {
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(body));
+      };
+      if (/^\/repos\/[^/]+\/[^/]+\/commits\/?$/.test(url.pathname)) {
+        return json(200, [{ sha: "itest0000000000000000000000000000000000" }]);
+      }
+      if (/^\/repos\/[^/]+\/[^/]+\/contents\/.+$/.test(url.pathname)) {
+        const raw = Buffer.from(JSON.stringify(gitTaskDefinition));
+        return json(200, {
+          type: "file",
+          encoding: "base64",
+          content: raw.toString("base64"),
+          size: raw.length,
+        });
+      }
+      json(404, { message: "Not Found" });
+    });
+    await new Promise<void>((resolve) => stubServer.listen(0, resolve));
+    const port = (stubServer.address() as AddressInfo).port;
+
+    const github = new GitHub("dummy-token", `http://127.0.0.1:${port}`);
+    deployment = new Deployment(aws, github);
+    observer = new DefaultApplicationObserver(
+      new AwsServiceStateProvider(aws),
+      deployment
+    );
+
+    const initialArn = await aws.registerTaskDefinition(
+      application.awsConfig,
+      taskDefinitionJson() as never
+    );
+    await createClusterAndService(rawEcsClient(), cluster, service, initialArn);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      stubServer.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  it("reports InSync when ECS matches the git task definition", async () => {
+    const observed = await observer.observe(application);
+
+    expect(observed.service.status).toBe("Success");
+    expect(observed.sync.status).toBe("Success");
+    if (observed.sync.status === "Success") {
+      expect(observed.sync.value?.status).toBe("InSync");
+    }
+    if (observed.diff.status === "Success") {
+      expect(observed.diff.value).toHaveLength(0);
+    }
+  });
+
+  it("reports OutOfSync with a diff when git adds an environment variable", async () => {
+    gitTaskDefinition = taskDefinitionJson({
+      name: "DEPLOYED_FROM",
+      value: "git",
+    });
+
+    const observed = await observer.observe(application);
+
+    expect(observed.sync.status).toBe("Success");
+    if (observed.sync.status === "Success") {
+      expect(observed.sync.value?.status).toBe("OutOfSync");
+    }
+    expect(observed.diff.status).toBe("Success");
+    if (observed.diff.status === "Success") {
+      expect(observed.diff.value.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("syncService registers the git revision and returns to InSync", async () => {
+    await deployment.syncService(application);
+
+    const serviceState = await aws.describeServices(application.awsConfig, {
+      cluster,
+      service,
+    });
+    // sync で登録された新リビジョンがサービスに反映されている
+    expect(serviceState?.taskDefinition).toMatch(new RegExp(`${family}:\\d+`));
+
+    const observed = await observer.observe(application);
+    expect(observed.sync.status).toBe("Success");
+    if (observed.sync.status === "Success") {
+      expect(observed.sync.value?.status).toBe("InSync");
+    }
+  });
+
+  it("surfaces a typed error message for an invalid repository URL", async () => {
+    const badRepoApp = {
+      ...application,
+      gitConfig: { ...application.gitConfig, repo: "not-a-github-url" },
+    };
+
+    const observed = await observer.observe(badRepoApp);
+    expect(observed.sync.status).toBe("Error");
+    if (observed.sync.status === "Error") {
+      expect(observed.sync.reason).toContain("Invalid GitHub repository URL");
+    }
+  });
+});

--- a/ecscd/tests/integration/setup-env.js
+++ b/ecscd/tests/integration/setup-env.js
@@ -1,0 +1,11 @@
+// 統合テストのデフォルト接続先。compose 内では AWS_ENDPOINT_URL=http://ministack:4566 と
+// AWS_ENDPOINT_URL_ECS=http://ecs-sim:8081 が注入され、ホストから直接実行する場合は
+// それぞれの公開ポート (localhost:4566 / localhost:4600) に接続する。
+// AWS SDK v3 は AWS_ENDPOINT_URL[_<SERVICE>] / 認証情報の環境変数を標準で解決するため、
+// プロダクションコード側の変更は不要。
+process.env.AWS_ENDPOINT_URL = process.env.AWS_ENDPOINT_URL || "http://localhost:4566";
+process.env.AWS_ENDPOINT_URL_ECS =
+  process.env.AWS_ENDPOINT_URL_ECS || "http://localhost:4600";
+process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || "test";
+process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || "test";
+process.env.AWS_REGION = process.env.AWS_REGION || "us-east-1";

--- a/tools/ecs-sim/server.js
+++ b/tools/ecs-sim/server.js
@@ -1,0 +1,583 @@
+// ローカル動作確認用の ECS シミュレータ (依存パッケージなし)。
+//
+// MiniStack の ECS 実装は UpdateService が同期的に COMPLETED を返し、
+// ListServiceDeployments も未実装 (常に空配列) のため、実際の ECS のように
+// 「デプロイ直後は IN_PROGRESS、数秒〜数十秒後に COMPLETED/FAILED へ遷移する」
+// 挙動やロールバックを試すことができない。このサーバはそのギャップを埋めるため、
+// ecscd が使う ECS API のうち必要な部分だけを AWS JSON 1.1 プロトコルで実装し、
+// ローカルにインメモリの状態を持って擬似的な非同期ロールアウトを再現する。
+//
+// DynamoDB / STS は引き続き ministack が担当し、ECS だけこのサーバに向ける
+// (AWS SDK v3 は AWS_ENDPOINT_URL_ECS でサービス単位のエンドポイント上書きに対応している)。
+const http = require("http");
+const crypto = require("crypto");
+
+const PORT = Number(process.env.PORT || 8081);
+const REGION = process.env.AWS_REGION || "us-east-1";
+const ACCOUNT_ID = "000000000000";
+const HISTORY_LIMIT = 5;
+
+// ロールアウトの所要時間・結果分布。すべて環境変数で調整可能。
+const ROLLOUT_MIN_MS = Number(process.env.ECS_SIM_ROLLOUT_MIN_MS || 8_000);
+const ROLLOUT_MAX_MS = Number(process.env.ECS_SIM_ROLLOUT_MAX_MS || 25_000);
+const ROLLBACK_DURATION_MS = Number(
+  process.env.ECS_SIM_ROLLBACK_DURATION_MS || 4_000,
+);
+// hang (スタック) 状態はこの割合までしか進捗しない = 永遠に IN_PROGRESS のまま
+const HANG_STALL_RATIO = 0.4;
+// 通常デプロイの結果分布 (success / hang / failed)。hang はロールバック演習用、
+// failed は "Failed" 表示の確認用 (現行 UI ではロールバック不可)。
+const OUTCOME_WEIGHTS = parseWeights(
+  process.env.ECS_SIM_OUTCOME_WEIGHTS || "success:0.7,hang:0.2,failed:0.1",
+);
+
+function parseWeights(spec) {
+  const weights = {};
+  for (const part of spec.split(",")) {
+    const [key, value] = part.split(":");
+    if (key && value) weights[key.trim()] = Number(value);
+  }
+  return weights;
+}
+
+function pickWeighted(weights) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((sum, [, w]) => sum + w, 0);
+  let r = Math.random() * total;
+  for (const [key, w] of entries) {
+    if (r < w) return key;
+    r -= w;
+  }
+  return entries[entries.length - 1][0];
+}
+
+function randHex(bytes) {
+  return crypto.randomBytes(bytes).toString("hex");
+}
+
+function randomInt(min, max) {
+  return Math.floor(min + Math.random() * (max - min));
+}
+
+// AWS JSON 1.1 プロトコルのタイムスタンプは Unix epoch 秒 (number) で表現される。
+// Date を渡すと JSON.stringify が ISO 文字列にしてしまい、SDK 側の数値パースが
+// NaN になって Deserialization error になるため、常にこの形で渡す。
+function epochSeconds(ms) {
+  return ms / 1000;
+}
+
+// --- ARN ヘルパー ---------------------------------------------------------
+
+function taskDefinitionArn(family, revision) {
+  return `arn:aws:ecs:${REGION}:${ACCOUNT_ID}:task-definition/${family}:${revision}`;
+}
+function clusterArn(cluster) {
+  return `arn:aws:ecs:${REGION}:${ACCOUNT_ID}:cluster/${cluster}`;
+}
+function serviceArn(cluster, service) {
+  return `arn:aws:ecs:${REGION}:${ACCOUNT_ID}:service/${cluster}/${service}`;
+}
+function serviceDeploymentArn(cluster, service, id) {
+  return `arn:aws:ecs:${REGION}:${ACCOUNT_ID}:service-deployment/${cluster}/${service}/${id}`;
+}
+
+// --- 状態 -------------------------------------------------------------
+
+const taskDefinitions = new Map(); // family -> array of stored task definitions (index 0 = revision 1)
+const clusters = new Set();
+const services = new Map(); // "cluster::service" -> serviceState
+const forcedNext = new Map(); // "cluster::service" -> { outcome, durationMs } (次回 UpdateService だけに適用)
+
+function serviceKey(cluster, service) {
+  return `${cluster}::${service}`;
+}
+
+// 実 AWS が RegisterTaskDefinition 時に補完するサーバ側デフォルトを再現する
+// (taskRoleArn/executionRoleArn/pidMode/ipcMode の空文字、コンテナ cpu:0)。
+// docs/local-verification.md の「サーバ側デフォルトによる幻の差分」を参照。
+function completeTaskDefinition(input) {
+  const td = { ...input };
+  td.taskRoleArn = td.taskRoleArn ?? "";
+  td.executionRoleArn = td.executionRoleArn ?? "";
+  td.pidMode = td.pidMode ?? "";
+  td.ipcMode = td.ipcMode ?? "";
+  td.containerDefinitions = (td.containerDefinitions || []).map((c) => ({
+    ...c,
+    cpu: c.cpu ?? 0,
+  }));
+  return td;
+}
+
+function resolveTaskDefinition(ref) {
+  if (!ref) return null;
+  let family;
+  let revision;
+  const arnMatch = ref.match(/task-definition\/([^:/]+):(\d+)$/);
+  if (arnMatch) {
+    family = arnMatch[1];
+    revision = Number(arnMatch[2]);
+  } else if (ref.includes(":")) {
+    const [f, r] = ref.split(":");
+    family = f;
+    revision = Number(r);
+  } else {
+    family = ref;
+  }
+  const revisions = taskDefinitions.get(family);
+  if (!revisions || revisions.length === 0) return null;
+  if (revision) return revisions.find((r) => r.revision === revision) || null;
+  return revisions[revisions.length - 1];
+}
+
+function createRollout({
+  cluster,
+  service,
+  taskDefinitionArn: targetArn,
+  previousTaskDefinitionArn,
+  desiredCount,
+  forceOutcome,
+  forceDurationMs,
+}) {
+  const key = serviceKey(cluster, service);
+  const forced = forceOutcome ? null : forcedNext.get(key);
+  if (forced) forcedNext.delete(key);
+
+  const outcome = forceOutcome || forced?.outcome || pickWeighted(OUTCOME_WEIGHTS);
+  const durationMs =
+    forceDurationMs ?? forced?.durationMs ?? randomInt(ROLLOUT_MIN_MS, ROLLOUT_MAX_MS);
+
+  return {
+    id: `ecs-svc/${randHex(10)}`,
+    serviceDeploymentArn: serviceDeploymentArn(cluster, service, randHex(10)),
+    taskDefinitionArn: targetArn,
+    previousTaskDefinitionArn: previousTaskDefinitionArn || null,
+    desiredCount,
+    createdAt: Date.now(),
+    rolloutDurationMs: Math.max(durationMs, 1),
+    outcome, // 'success' | 'hang' | 'failed'
+    stoppedAt: null,
+  };
+}
+
+function progressRatio(rollout, elapsedMs) {
+  if (rollout.outcome === "hang") {
+    const ramp = Math.min(1, elapsedMs / rollout.rolloutDurationMs);
+    return Math.min(HANG_STALL_RATIO, ramp * HANG_STALL_RATIO);
+  }
+  return Math.min(1, elapsedMs / rollout.rolloutDurationMs);
+}
+
+// ロールアウトの「今の見え方」を経過時間から都度計算する (タイマーは使わない)。
+function deriveView(rollout, now) {
+  const desired = rollout.desiredCount;
+
+  if (rollout.stoppedAt) {
+    const ratio = progressRatio(rollout, rollout.stoppedAt - rollout.createdAt);
+    const running = Math.floor(desired * ratio);
+    return {
+      phase: "FAILED",
+      rolloutState: "FAILED",
+      reason:
+        "ECS deployment failed: rolled back to the previous task definition.",
+      serviceDeploymentStatus: "STOPPED",
+      runningCount: running,
+      pendingCount: 0,
+      failedTasks: Math.max(desired - running, 0),
+    };
+  }
+
+  const elapsed = now - rollout.createdAt;
+  const ratio = progressRatio(rollout, elapsed);
+
+  if (ratio < 1) {
+    const running = Math.floor(desired * ratio);
+    return {
+      phase: "IN_PROGRESS",
+      rolloutState: "IN_PROGRESS",
+      reason:
+        rollout.outcome === "hang"
+          ? "ECS deployment in progress: waiting for tasks to reach a healthy state."
+          : "ECS deployment in progress.",
+      serviceDeploymentStatus: "IN_PROGRESS",
+      runningCount: running,
+      pendingCount: desired - running,
+      failedTasks: 0,
+    };
+  }
+
+  if (rollout.outcome === "failed") {
+    return {
+      phase: "FAILED",
+      rolloutState: "FAILED",
+      reason:
+        "ECS deployment circuit breaker: tasks failed to reach a healthy state.",
+      serviceDeploymentStatus: "FAILED",
+      runningCount: 0,
+      pendingCount: 0,
+      failedTasks: desired,
+    };
+  }
+
+  return {
+    phase: "COMPLETED",
+    rolloutState: "COMPLETED",
+    reason: "ECS deployment completed.",
+    serviceDeploymentStatus: "SUCCESSFUL",
+    runningCount: desired,
+    pendingCount: 0,
+    failedTasks: 0,
+  };
+}
+
+function buildServiceOutput(state, now) {
+  const rollouts = state.rollouts.slice(0, HISTORY_LIMIT);
+  const primaryView = deriveView(rollouts[0], now);
+
+  const deployments = rollouts.map((rollout, idx) => {
+    const view = deriveView(rollout, now);
+    let status;
+    if (idx === 0) status = "PRIMARY";
+    else if (idx === 1 && primaryView.phase !== "COMPLETED") status = "ACTIVE";
+    else status = "INACTIVE";
+    const serving = status !== "INACTIVE";
+
+    return {
+      id: rollout.id,
+      status,
+      taskDefinition: rollout.taskDefinitionArn,
+      desiredCount: rollout.desiredCount,
+      pendingCount: serving ? view.pendingCount : 0,
+      runningCount: serving ? view.runningCount : 0,
+      failedTasks: view.failedTasks,
+      createdAt: epochSeconds(rollout.createdAt),
+      updatedAt: epochSeconds(now),
+      launchType: "EC2",
+      rolloutState: view.rolloutState,
+      rolloutStateReason: view.reason,
+    };
+  });
+
+  return {
+    serviceArn: serviceArn(state.cluster, state.service),
+    serviceName: state.service,
+    clusterArn: clusterArn(state.cluster),
+    status: "ACTIVE",
+    desiredCount: state.desiredCount,
+    runningCount: deployments.reduce((sum, d) => sum + d.runningCount, 0),
+    pendingCount: deployments.reduce((sum, d) => sum + d.pendingCount, 0),
+    launchType: "EC2",
+    taskDefinition: rollouts[0].taskDefinitionArn,
+    deploymentConfiguration: {
+      deploymentCircuitBreaker: { enable: false, rollback: false },
+      maximumPercent: 200,
+      minimumHealthyPercent: 100,
+    },
+    deployments,
+    roleArn: "",
+    events: [],
+    createdAt: epochSeconds(state.createdAt),
+    networkConfiguration: {},
+    healthCheckGracePeriodSeconds: 0,
+    schedulingStrategy: "REPLICA",
+    deploymentController: { type: "ECS" },
+    tags: [],
+    createdBy: "arn:aws:iam::000000000000:root",
+    enableECSManagedTags: false,
+    propagateTags: "NONE",
+    enableExecuteCommand: false,
+  };
+}
+
+// --- ECS アクション -----------------------------------------------------
+
+const actions = {
+  CreateCluster(input) {
+    const name = input.clusterName;
+    clusters.add(name);
+    return {
+      cluster: { clusterArn: clusterArn(name), clusterName: name, status: "ACTIVE" },
+    };
+  },
+
+  // init スクリプトの起動待ちチェックにのみ使う (readiness probe)。
+  ListClusters() {
+    return { clusterArns: Array.from(clusters, clusterArn) };
+  },
+
+  RegisterTaskDefinition(input) {
+    const family = input.family;
+    if (!family) {
+      throw new ApiError(400, "InvalidParameterException", "family is required");
+    }
+    const revisions = taskDefinitions.get(family) || [];
+    const revision = revisions.length + 1;
+    const completed = completeTaskDefinition(input);
+    const stored = {
+      ...completed,
+      family,
+      revision,
+      taskDefinitionArn: taskDefinitionArn(family, revision),
+      status: "ACTIVE",
+      registeredAt: epochSeconds(Date.now()),
+      requiresAttributes: [],
+      compatibilities: completed.requiresCompatibilities || ["EC2"],
+    };
+    revisions.push(stored);
+    taskDefinitions.set(family, revisions);
+    return { taskDefinition: stored };
+  },
+
+  DescribeTaskDefinition(input) {
+    const found = resolveTaskDefinition(input.taskDefinition);
+    if (!found) {
+      throw new ApiError(
+        400,
+        "ClientException",
+        `Unable to describe task definition: ${input.taskDefinition}`,
+      );
+    }
+    return { taskDefinition: found };
+  },
+
+  CreateService(input) {
+    const { cluster, serviceName, taskDefinition, desiredCount } = input;
+    clusters.add(cluster);
+    const key = serviceKey(cluster, serviceName);
+    const existing = services.get(key);
+    if (existing) {
+      return { service: buildServiceOutput(existing, Date.now()) };
+    }
+    const resolved = resolveTaskDefinition(taskDefinition);
+    if (!resolved) {
+      throw new ApiError(
+        400,
+        "ClientException",
+        `Unable to resolve task definition: ${taskDefinition}`,
+      );
+    }
+    // 初回起動は待たされてもうれしくないので、ほぼ即座に COMPLETED にする。
+    const rollout = createRollout({
+      cluster,
+      service: serviceName,
+      taskDefinitionArn: resolved.taskDefinitionArn,
+      previousTaskDefinitionArn: null,
+      desiredCount: desiredCount ?? 1,
+      forceOutcome: "success",
+      forceDurationMs: 1,
+    });
+    const state = {
+      cluster,
+      service: serviceName,
+      desiredCount: desiredCount ?? 1,
+      createdAt: Date.now(),
+      rollouts: [rollout],
+    };
+    services.set(key, state);
+    return { service: buildServiceOutput(state, Date.now()) };
+  },
+
+  DescribeServices(input) {
+    const { cluster, services: names } = input;
+    const results = [];
+    const failures = [];
+    for (const name of names || []) {
+      const state = services.get(serviceKey(cluster, name));
+      if (!state) {
+        failures.push({ arn: serviceArn(cluster, name), reason: "MISSING" });
+        continue;
+      }
+      results.push(buildServiceOutput(state, Date.now()));
+    }
+    return { services: results, failures };
+  },
+
+  UpdateService(input) {
+    const { cluster, service, taskDefinition, desiredCount } = input;
+    const key = serviceKey(cluster, service);
+    const state = services.get(key);
+    if (!state) {
+      throw new ApiError(400, "ServiceNotFoundException", `Service not found: ${service}`);
+    }
+    const resolved = resolveTaskDefinition(taskDefinition);
+    if (!resolved) {
+      throw new ApiError(
+        400,
+        "ClientException",
+        `Unable to resolve task definition: ${taskDefinition}`,
+      );
+    }
+    if (typeof desiredCount === "number") {
+      state.desiredCount = desiredCount;
+    }
+    const previousArn = state.rollouts[0].taskDefinitionArn;
+    const rollout = createRollout({
+      cluster,
+      service,
+      taskDefinitionArn: resolved.taskDefinitionArn,
+      previousTaskDefinitionArn: previousArn,
+      desiredCount: state.desiredCount,
+    });
+    state.rollouts.unshift(rollout);
+    state.rollouts.length = Math.min(state.rollouts.length, HISTORY_LIMIT);
+    return { service: buildServiceOutput(state, Date.now()) };
+  },
+
+  ListServiceDeployments(input) {
+    const { cluster, service } = input;
+    const state = services.get(serviceKey(cluster, service));
+    if (!state) return { serviceDeployments: [] };
+    const now = Date.now();
+    const serviceDeployments = state.rollouts.slice(0, HISTORY_LIMIT).map((rollout) => {
+      const view = deriveView(rollout, now);
+      return {
+        serviceDeploymentArn: rollout.serviceDeploymentArn,
+        serviceArn: serviceArn(cluster, service),
+        clusterArn: clusterArn(cluster),
+        createdAt: epochSeconds(rollout.createdAt),
+        startedAt: epochSeconds(rollout.createdAt),
+        finishedAt:
+          view.phase === "IN_PROGRESS" ? undefined : epochSeconds(now),
+        updatedAt: epochSeconds(now),
+        status: view.serviceDeploymentStatus,
+        statusReason: view.reason,
+        targetServiceRevision: { arn: rollout.taskDefinitionArn },
+      };
+    });
+    return { serviceDeployments };
+  },
+
+  StopServiceDeployment(input) {
+    const { serviceDeploymentArn: arn } = input;
+    for (const state of services.values()) {
+      const primary = state.rollouts[0];
+      if (primary.serviceDeploymentArn !== arn) continue;
+      const view = deriveView(primary, Date.now());
+      if (view.phase !== "IN_PROGRESS") {
+        throw new ApiError(
+          400,
+          "InvalidParameterException",
+          "Deployment is not in progress and cannot be stopped.",
+        );
+      }
+      primary.stoppedAt = Date.now();
+      const rollback = createRollout({
+        cluster: state.cluster,
+        service: state.service,
+        taskDefinitionArn: primary.previousTaskDefinitionArn || primary.taskDefinitionArn,
+        previousTaskDefinitionArn: primary.taskDefinitionArn,
+        desiredCount: state.desiredCount,
+        forceOutcome: "success",
+        forceDurationMs: ROLLBACK_DURATION_MS,
+      });
+      state.rollouts.unshift(rollback);
+      state.rollouts.length = Math.min(state.rollouts.length, HISTORY_LIMIT);
+      return { serviceDeploymentArn: arn };
+    }
+    throw new ApiError(
+      400,
+      "ServiceDeploymentNotFoundException",
+      `No matching service deployment found for ${arn}`,
+    );
+  },
+};
+
+class ApiError extends Error {
+  constructor(status, type, message) {
+    super(message);
+    this.status = status;
+    this.type = type;
+  }
+}
+
+// --- 制御用エンドポイント (非 AWS プロトコル、docs/local-verification.md 参照) ---
+// 次回の UpdateService の結果 (success/hang/failed) と所要時間を強制する。
+// hang を明示的に発生させてロールバック操作を確実に試したいときに使う。
+
+function handleControlRequest(req, res, url, body) {
+  if (req.method === "POST" && url.pathname === "/_sim/next-deployment") {
+    const { cluster, service, outcome, durationMs } = body || {};
+    if (!cluster || !service || !["success", "hang", "failed"].includes(outcome)) {
+      return sendJson(res, 400, {
+        error: "cluster, service and outcome ('success'|'hang'|'failed') are required",
+      });
+    }
+    forcedNext.set(serviceKey(cluster, service), {
+      outcome,
+      durationMs: durationMs ? Number(durationMs) : undefined,
+    });
+    return sendJson(res, 200, { ok: true });
+  }
+
+  if (req.method === "GET" && url.pathname === "/_sim/state") {
+    const now = Date.now();
+    const dump = {};
+    for (const [key, state] of services) {
+      dump[key] = buildServiceOutput(state, now);
+    }
+    return sendJson(res, 200, { services: dump });
+  }
+
+  return sendJson(res, 404, { error: "not found" });
+}
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/x-amz-json-1.1",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+const server = http.createServer((req, res) => {
+  const chunks = [];
+  req.on("data", (chunk) => chunks.push(chunk));
+  req.on("end", () => {
+    const raw = Buffer.concat(chunks).toString("utf8");
+    const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+    const target = req.headers["x-amz-target"];
+
+    if (!target) {
+      let body;
+      try {
+        body = raw ? JSON.parse(raw) : {};
+      } catch {
+        body = {};
+      }
+      console.log(`${req.method} ${url.pathname}`);
+      return handleControlRequest(req, res, url, body);
+    }
+
+    const action = String(target).split(".").pop();
+    console.log(`ECS ${action}`);
+    const handler = actions[action];
+    if (!handler) {
+      return sendJson(res, 400, {
+        __type: "UnknownOperationException",
+        message: `Unsupported action: ${action}`,
+      });
+    }
+
+    try {
+      const input = raw ? JSON.parse(raw) : {};
+      const output = handler(input);
+      return sendJson(res, 200, output);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return sendJson(res, error.status, {
+          __type: error.type,
+          message: error.message,
+        });
+      }
+      console.error(error);
+      return sendJson(res, 500, {
+        __type: "InternalFailure",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`ecs-sim listening on :${PORT} (region: ${REGION})`);
+});

--- a/tools/ecs-sim/server.js
+++ b/tools/ecs-sim/server.js
@@ -17,12 +17,36 @@ const REGION = process.env.AWS_REGION || "us-east-1";
 const ACCOUNT_ID = "000000000000";
 const HISTORY_LIMIT = 5;
 
+// 環境変数を正の有限数 (ミリ秒) として読む。不正な値 (非数値・0以下) の場合は
+// NaN がロールアウトの進捗計算に混入して即時完了などを起こすため、
+// 警告を出して安全なデフォルトにフォールバックする。
+function parsePositiveMs(envVarName, defaultValue) {
+  const raw = process.env[envVarName];
+  if (raw === undefined) return defaultValue;
+  const num = Number(raw);
+  if (!Number.isFinite(num) || num <= 0) {
+    console.error(
+      `invalid ${envVarName} ("${raw}"); falling back to ${defaultValue}`,
+    );
+    return defaultValue;
+  }
+  return num;
+}
+
 // ロールアウトの所要時間・結果分布。すべて環境変数で調整可能。
-const ROLLOUT_MIN_MS = Number(process.env.ECS_SIM_ROLLOUT_MIN_MS || 8_000);
-const ROLLOUT_MAX_MS = Number(process.env.ECS_SIM_ROLLOUT_MAX_MS || 25_000);
-const ROLLBACK_DURATION_MS = Number(
-  process.env.ECS_SIM_ROLLBACK_DURATION_MS || 4_000,
+const ROLLOUT_MIN_MS = parsePositiveMs("ECS_SIM_ROLLOUT_MIN_MS", 8_000);
+let ROLLOUT_MAX_MS = parsePositiveMs("ECS_SIM_ROLLOUT_MAX_MS", 25_000);
+const ROLLBACK_DURATION_MS = parsePositiveMs(
+  "ECS_SIM_ROLLBACK_DURATION_MS",
+  4_000,
 );
+
+if (ROLLOUT_MAX_MS < ROLLOUT_MIN_MS) {
+  console.error(
+    `ECS_SIM_ROLLOUT_MAX_MS (${ROLLOUT_MAX_MS}) < ECS_SIM_ROLLOUT_MIN_MS (${ROLLOUT_MIN_MS}); clamping max to min`,
+  );
+  ROLLOUT_MAX_MS = ROLLOUT_MIN_MS;
+}
 // hang (スタック) 状態はこの割合までしか進捗しない = 永遠に IN_PROGRESS のまま
 const HANG_STALL_RATIO = 0.4;
 // 通常デプロイの結果分布 (success / hang / failed)。hang はロールバック演習用、

--- a/tools/ecs-sim/server.js
+++ b/tools/ecs-sim/server.js
@@ -247,9 +247,18 @@ function buildServiceOutput(state, now) {
   const deployments = rollouts.map((rollout, idx) => {
     const view = deriveView(rollout, now);
     let status;
-    if (idx === 0) status = "PRIMARY";
-    else if (idx === 1 && primaryView.phase !== "COMPLETED") status = "ACTIVE";
-    else status = "INACTIVE";
+    if (rollout.stoppedAt) {
+      // ロールバックで置き換えられたデプロイは常に INACTIVE (集計対象外)。
+      // stoppedAt が付いた時点で新しい rollout が rollouts[0] を占めるため、
+      // idx による判定より優先する。
+      status = "INACTIVE";
+    } else if (idx === 0) {
+      status = "PRIMARY";
+    } else if (idx === 1 && primaryView.phase !== "COMPLETED") {
+      status = "ACTIVE";
+    } else {
+      status = "INACTIVE";
+    }
     const serving = status !== "INACTIVE";
 
     return {

--- a/tools/ecs-sim/server.js
+++ b/tools/ecs-sim/server.js
@@ -512,9 +512,20 @@ function handleControlRequest(req, res, url, body) {
         error: "cluster, service and outcome ('success'|'hang'|'failed') are required",
       });
     }
+    // durationMs は truthy 判定だと 0 を指定できないうえ NaN/負数がすり抜けるので、
+    // 与えられた場合は正の有限数であることを検証する。
+    let parsedDurationMs;
+    if (durationMs !== undefined && durationMs !== null) {
+      parsedDurationMs = Number(durationMs);
+      if (!Number.isFinite(parsedDurationMs) || parsedDurationMs <= 0) {
+        return sendControlJson(res, 400, {
+          error: "durationMs must be a positive finite number",
+        });
+      }
+    }
     forcedNext.set(serviceKey(cluster, service), {
       outcome,
-      durationMs: durationMs ? Number(durationMs) : undefined,
+      durationMs: parsedDurationMs,
     });
     return sendControlJson(res, 200, { ok: true });
   }

--- a/tools/ecs-sim/server.js
+++ b/tools/ecs-sim/server.js
@@ -35,7 +35,18 @@ function parseWeights(spec) {
   const weights = {};
   for (const part of spec.split(",")) {
     const [key, value] = part.split(":");
-    if (key && value) weights[key.trim()] = Number(value);
+    const num = Number(value);
+    if (key && Number.isFinite(num) && num > 0) {
+      weights[key.trim()] = num;
+    }
+  }
+  // 不正な指定 (空文字・全滅など) だと pickWeighted が空の entries を掴んで落ちるので、
+  // ここで検証して安全なデフォルト (success 固定) にフォールバックする。
+  if (Object.keys(weights).length === 0) {
+    console.error(
+      `invalid ECS_SIM_OUTCOME_WEIGHTS ("${spec}"); falling back to success-only`,
+    );
+    return { success: 1 };
   }
   return weights;
 }
@@ -497,7 +508,7 @@ function handleControlRequest(req, res, url, body) {
   if (req.method === "POST" && url.pathname === "/_sim/next-deployment") {
     const { cluster, service, outcome, durationMs } = body || {};
     if (!cluster || !service || !["success", "hang", "failed"].includes(outcome)) {
-      return sendJson(res, 400, {
+      return sendControlJson(res, 400, {
         error: "cluster, service and outcome ('success'|'hang'|'failed') are required",
       });
     }
@@ -505,7 +516,7 @@ function handleControlRequest(req, res, url, body) {
       outcome,
       durationMs: durationMs ? Number(durationMs) : undefined,
     });
-    return sendJson(res, 200, { ok: true });
+    return sendControlJson(res, 200, { ok: true });
   }
 
   if (req.method === "GET" && url.pathname === "/_sim/state") {
@@ -514,16 +525,27 @@ function handleControlRequest(req, res, url, body) {
     for (const [key, state] of services) {
       dump[key] = buildServiceOutput(state, now);
     }
-    return sendJson(res, 200, { services: dump });
+    return sendControlJson(res, 200, { services: dump });
   }
 
-  return sendJson(res, 404, { error: "not found" });
+  return sendControlJson(res, 404, { error: "not found" });
 }
 
-function sendJson(res, status, body) {
+// AWS JSON 1.1 プロトコル (ECS API) のレスポンス用。
+function sendAwsJson(res, status, body) {
+  sendJson(res, status, body, "application/x-amz-json-1.1");
+}
+
+// /_sim/* 制御用エンドポイント (非 AWS プロトコル) のレスポンス用。
+// AWS プロトコルと同じ Content-Type を使うとツール/デバッグ時に紛らわしいため分ける。
+function sendControlJson(res, status, body) {
+  sendJson(res, status, body, "application/json; charset=utf-8");
+}
+
+function sendJson(res, status, body, contentType) {
   const payload = JSON.stringify(body);
   res.writeHead(status, {
-    "Content-Type": "application/x-amz-json-1.1",
+    "Content-Type": contentType,
     "Content-Length": Buffer.byteLength(payload),
   });
   res.end(payload);
@@ -552,7 +574,7 @@ const server = http.createServer((req, res) => {
     console.log(`ECS ${action}`);
     const handler = actions[action];
     if (!handler) {
-      return sendJson(res, 400, {
+      return sendAwsJson(res, 400, {
         __type: "UnknownOperationException",
         message: `Unsupported action: ${action}`,
       });
@@ -561,16 +583,16 @@ const server = http.createServer((req, res) => {
     try {
       const input = raw ? JSON.parse(raw) : {};
       const output = handler(input);
-      return sendJson(res, 200, output);
+      return sendAwsJson(res, 200, output);
     } catch (error) {
       if (error instanceof ApiError) {
-        return sendJson(res, error.status, {
+        return sendAwsJson(res, error.status, {
           __type: error.type,
           message: error.message,
         });
       }
       console.error(error);
-      return sendJson(res, 500, {
+      return sendAwsJson(res, 500, {
         __type: "InternalFailure",
         message: error instanceof Error ? error.message : "Unknown error",
       });

--- a/tools/github-stub/data/task-definition.json
+++ b/tools/github-stub/data/task-definition.json
@@ -1,0 +1,22 @@
+{
+  "family": "ecscd-demo",
+  "networkMode": "bridge",
+  "requiresCompatibilities": ["EC2"],
+  "taskRoleArn": "",
+  "executionRoleArn": "",
+  "cpu": "256",
+  "memory": "512",
+  "pidMode": "",
+  "ipcMode": "",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "busybox:latest",
+      "command": ["sleep", "3600"],
+      "cpu": 0,
+      "memory": 64,
+      "essential": true,
+      "environment": [{ "name": "DEPLOYED_FROM", "value": "git" }]
+    }
+  ]
+}

--- a/tools/github-stub/server.js
+++ b/tools/github-stub/server.js
@@ -1,0 +1,65 @@
+// GitHub REST API の最小スタブ (依存パッケージなし)。
+// ecscd が使う 2 エンドポイントのみ実装する:
+//   GET /repos/{owner}/{repo}/commits            -> [{ sha }]
+//   GET /repos/{owner}/{repo}/contents/{path}    -> { content: base64(DATA_DIR/{path}) }
+// DATA_DIR 配下のファイルを編集するとタスク定義の「Git 側の望ましい状態」を変更できる。
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const port = Number(process.env.PORT || 8080);
+const dataDir = path.resolve(process.env.DATA_DIR || path.join(__dirname, "data"));
+
+function send(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+  console.log(`${req.method} ${url.pathname}${url.search}`);
+
+  if (req.method !== "GET") {
+    return send(res, 405, { message: "Method Not Allowed" });
+  }
+
+  // listCommits: 固定 SHA を 1 件返す (ecscd は先頭コミットの SHA しか見ない)
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/?$/.test(url.pathname)) {
+    return send(res, 200, [
+      { sha: "stub0000000000000000000000000000000000ca" },
+    ]);
+  }
+
+  // getContent: DATA_DIR 配下のファイルを base64 で返す
+  const contents = url.pathname.match(/^\/repos\/[^/]+\/[^/]+\/contents\/(.+)$/);
+  if (contents) {
+    const rel = decodeURIComponent(contents[1]);
+    const resolved = path.resolve(dataDir, rel);
+    if (!resolved.startsWith(dataDir + path.sep) && resolved !== dataDir) {
+      return send(res, 404, { message: "Not Found" });
+    }
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+      return send(res, 404, { message: "Not Found" });
+    }
+    const raw = fs.readFileSync(resolved);
+    return send(res, 200, {
+      type: "file",
+      name: path.basename(rel),
+      path: rel,
+      sha: "stubfile0000000000000000000000000000000",
+      size: raw.length,
+      encoding: "base64",
+      content: raw.toString("base64"),
+    });
+  }
+
+  send(res, 404, { message: "Not Found" });
+});
+
+server.listen(port, () => {
+  console.log(`github-stub listening on :${port} (data: ${dataDir})`);
+});

--- a/tools/github-stub/server.js
+++ b/tools/github-stub/server.js
@@ -39,7 +39,13 @@ const server = http.createServer((req, res) => {
   // getContent: DATA_DIR 配下のファイルを base64 で返す
   const contents = url.pathname.match(/^\/repos\/[^/]+\/[^/]+\/contents\/(.+)$/);
   if (contents) {
-    const rel = decodeURIComponent(contents[1]);
+    let rel;
+    try {
+      rel = decodeURIComponent(contents[1]);
+    } catch {
+      // 不正な % エンコーディングは URIError を投げてプロセスが落ちるので、400 にする
+      return send(res, 400, { message: "Bad Request" });
+    }
     const resolved = path.resolve(dataDir, rel);
     if (!resolved.startsWith(dataDir + path.sep) && resolved !== dataDir) {
       return send(res, 404, { message: "Not Found" });

--- a/tools/github-stub/server.js
+++ b/tools/github-stub/server.js
@@ -8,7 +8,9 @@ const fs = require("fs");
 const path = require("path");
 
 const port = Number(process.env.PORT || 8080);
-const dataDir = path.resolve(process.env.DATA_DIR || path.join(__dirname, "data"));
+const dataDir = fs.realpathSync(
+  path.resolve(process.env.DATA_DIR || path.join(__dirname, "data")),
+);
 
 function send(res, status, body) {
   const payload = JSON.stringify(body);
@@ -43,6 +45,12 @@ const server = http.createServer((req, res) => {
       return send(res, 404, { message: "Not Found" });
     }
     if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+      return send(res, 404, { message: "Not Found" });
+    }
+    // シンボリックリンクで DATA_DIR の外を指していないか、実パスで再確認する
+    // (上の startsWith チェックは字面上のパスだけなのでリンクをすり抜けられる)。
+    const realResolved = fs.realpathSync(resolved);
+    if (!realResolved.startsWith(dataDir + path.sep) && realResolved !== dataDir) {
       return send(res, 404, { message: "Not Found" });
     }
     const raw = fs.readFileSync(resolved);

--- a/tools/github-stub/server.js
+++ b/tools/github-stub/server.js
@@ -53,7 +53,8 @@ const server = http.createServer((req, res) => {
     if (!realResolved.startsWith(dataDir + path.sep) && realResolved !== dataDir) {
       return send(res, 404, { message: "Not Found" });
     }
-    const raw = fs.readFileSync(resolved);
+    // TOCTOU を避けるため、検証したのと同じ実パス (realResolved) から読む
+    const raw = fs.readFileSync(realResolved);
     return send(res, 200, {
       type: "file",
       name: path.basename(rel),

--- a/tools/ministack-init/init.sh
+++ b/tools/ministack-init/init.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# ministack (DynamoDB) / ecs-sim (ECS) にデモ用リソースを投入する (冪等)。
+#   - DynamoDB テーブル ECSCD
+#   - ECS クラスタ demo-cluster / サービス demo-service (初期タスク定義: 環境変数なし)
+#   - ecscd アプリケーション登録 (demo-app)
+# github-stub 側のタスク定義には環境変数 DEPLOYED_FROM=git が入っているため、
+# 起動直後の demo-app は OutOfSync になり、Sync ボタンでデプロイを試せる。
+set -eu
+
+EP="${AWS_ENDPOINT_URL:-http://ministack:4566}"
+ECS_EP="${AWS_ENDPOINT_URL_ECS:-http://ecs-sim:8081}"
+CLUSTER=demo-cluster
+SERVICE=demo-service
+FAMILY=ecscd-demo
+TABLE="${DYNAMODB_TABLE_NAME:-ECSCD}"
+
+echo "waiting for ministack at ${EP} ..."
+i=0
+until aws --endpoint-url "$EP" sts get-caller-identity >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -gt 60 ]; then
+    echo "ministack did not become ready in time" >&2
+    exit 1
+  fi
+  sleep 2
+done
+echo "ministack is ready."
+
+echo "waiting for ecs-sim at ${ECS_EP} ..."
+i=0
+until aws --endpoint-url "$ECS_EP" ecs list-clusters >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -gt 60 ]; then
+    echo "ecs-sim did not become ready in time" >&2
+    exit 1
+  fi
+  sleep 1
+done
+echo "ecs-sim is ready."
+
+# --- DynamoDB -----------------------------------------------------------
+if aws --endpoint-url "$EP" dynamodb describe-table --table-name "$TABLE" >/dev/null 2>&1; then
+  echo "table ${TABLE} already exists"
+else
+  aws --endpoint-url "$EP" dynamodb create-table \
+    --table-name "$TABLE" \
+    --attribute-definitions AttributeName=name,AttributeType=S \
+    --key-schema AttributeName=name,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST >/dev/null
+  echo "created table ${TABLE}"
+fi
+
+# --- ECS (ecs-sim) --------------------------------------------------------
+aws --endpoint-url "$ECS_EP" ecs create-cluster --cluster-name "$CLUSTER" >/dev/null
+echo "cluster ${CLUSTER} is ready"
+
+# 初期リビジョン: github-stub 側 (DEPLOYED_FROM=git あり) と意図的に差分を作る
+if ! aws --endpoint-url "$ECS_EP" ecs describe-task-definition --task-definition "$FAMILY" >/dev/null 2>&1; then
+  # DescribeTaskDefinition が補完するサーバ側デフォルト (cpu/memory 等) まで明示し、
+  # github-stub 側との差分が「environment の有無」だけになるようにする
+  aws --endpoint-url "$ECS_EP" ecs register-task-definition --cli-input-json '{
+    "family": "ecscd-demo",
+    "networkMode": "bridge",
+    "requiresCompatibilities": ["EC2"],
+    "taskRoleArn": "",
+    "executionRoleArn": "",
+    "cpu": "256",
+    "memory": "512",
+    "pidMode": "",
+    "ipcMode": "",
+    "containerDefinitions": [
+      {
+        "name": "app",
+        "image": "busybox:latest",
+        "command": ["sleep", "3600"],
+        "cpu": 0,
+        "memory": 64,
+        "essential": true
+      }
+    ]
+  }' >/dev/null
+  echo "registered task definition ${FAMILY}"
+fi
+
+SERVICE_STATUS="$(aws --endpoint-url "$ECS_EP" ecs describe-services \
+  --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].status' --output text 2>/dev/null || echo NONE)"
+if [ "$SERVICE_STATUS" != "ACTIVE" ]; then
+  aws --endpoint-url "$ECS_EP" ecs create-service \
+    --cluster "$CLUSTER" \
+    --service-name "$SERVICE" \
+    --task-definition "$FAMILY" \
+    --desired-count 1 >/dev/null
+  echo "created service ${SERVICE}"
+else
+  echo "service ${SERVICE} already exists"
+fi
+
+# --- ecscd application row ----------------------------------------------
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+aws --endpoint-url "$EP" dynamodb put-item --table-name "$TABLE" --item '{
+  "name": {"S": "demo-app"},
+  "item_type": {"S": "application"},
+  "git_repo": {"S": "https://github.com/demo/app"},
+  "git_branch": {"S": "main"},
+  "git_path": {"S": "task-definition.json"},
+  "ecs_cluster": {"S": "'"$CLUSTER"'"},
+  "ecs_service": {"S": "'"$SERVICE"'"},
+  "aws_region": {"S": "us-east-1"},
+  "aws_role_arn": {"S": ""},
+  "aws_external_id": {"S": "local-demo"},
+  "created_at": {"S": "'"$NOW"'"},
+  "updated_at": {"S": "'"$NOW"'"}
+}' >/dev/null
+echo "registered ecscd application demo-app"
+
+echo "ministack init done."

--- a/tools/ministack-init/init.sh
+++ b/tools/ministack-init/init.sh
@@ -59,7 +59,7 @@ if ! aws --endpoint-url "$ECS_EP" ecs describe-task-definition --task-definition
   # DescribeTaskDefinition が補完するサーバ側デフォルト (cpu/memory 等) まで明示し、
   # github-stub 側との差分が「environment の有無」だけになるようにする
   aws --endpoint-url "$ECS_EP" ecs register-task-definition --cli-input-json '{
-    "family": "ecscd-demo",
+    "family": "'"$FAMILY"'",
     "networkMode": "bridge",
     "requiresCompatibilities": ["EC2"],
     "taskRoleArn": "",

--- a/tools/ministack-init/init.sh
+++ b/tools/ministack-init/init.sh
@@ -50,6 +50,18 @@ else
   echo "created table ${TABLE}"
 fi
 
+# create-table は非同期なので、put-item を投げる前に ACTIVE になるまで待つ
+i=0
+until [ "$(aws --endpoint-url "$EP" dynamodb describe-table --table-name "$TABLE" \
+  --query 'Table.TableStatus' --output text 2>/dev/null)" = "ACTIVE" ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 30 ]; then
+    echo "table ${TABLE} did not become ACTIVE in time" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
 # --- ECS (ecs-sim) --------------------------------------------------------
 aws --endpoint-url "$ECS_EP" ecs create-cluster --cluster-name "$CLUSTER" >/dev/null
 echo "cluster ${CLUSTER} is ready"


### PR DESCRIPTION
## Summary
`feature/reviewed-by-fable` ブランチで注釈された9件の問題を修正:
- DynamoDB: `item_type` 属性のない main 時代のアプリ行が一覧から消える致命的バグ
- SQLite: 新規DB起動時に `filters` テーブル未作成のまま SELECT が走るレース
- `getApplicationStatus`: sync エラー判定がデプロイ中/失敗判定より先に評価され、ポーリングが恒久停止する不具合
- `lastSyncedAt` が DB に永続化されておらず常に undefined だった問題を解消(DynamoDB/SQLite 双方に `last_synced_at` を追加、SQLite は自動マイグレーション)
- rolloutStateReason の透過漏れ、rolloutState 不明時の "FAILED" 誤判定
- `(dashboard)` 配下の force-dynamic/Suspense 重複を共有 layout に一元化
- アプリ削除後に `onSuccess` を呼びエラー表示が固着する不具合
- デプロイ進行中でも Edit/Delete/Save が操作できてしまう問題
- 一時的なフェッチ失敗がキャッシュに恒久保存され再試行不能になる問題
- ポーリングが選択中アプリの Deploying 時にしか動かず、他アプリのデプロイ完了が反映されない問題

**Base を `feature/ministack` (#95) にしています。** このブランチの修正は #95 の MiniStack/ECS シミュレータ環境の上に成り立っているため、まず #95 をマージしてからこちらをマージしてください。

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `docker compose --profile test run --rm integration-test` (15 tests passed)