### PR TITLE
feat: PR/push 時に typecheck・lint・ユニットテストを走らせる CI を追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: ecscd
@@ -13,7 +16,7 @@ jobs:
   lint-typecheck-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    working-directory: ecscd
+
+jobs:
+  lint-typecheck-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: ecscd/package-lock.json
+
+      - run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
   lint-typecheck-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/ecscd/eslint.config.mjs
+++ b/ecscd/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     ignores: [
       "node_modules/**",

--- a/ecscd/src/components/application/status-indicator.tsx
+++ b/ecscd/src/components/application/status-indicator.tsx
@@ -38,6 +38,7 @@ function StatusReasonPopover({
   const isVisible = isOpen || isHovered;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe "mounted" flag, intentionally one-shot
     setIsMounted(true);
   }, []);
 
@@ -58,6 +59,7 @@ function StatusReasonPopover({
 
   useEffect(() => {
     if (!isVisible || !triggerRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resets position readiness when hidden
       setIsPositionReady(false);
       return;
     }

--- a/ecscd/src/components/dashboard/sidebar-pane.tsx
+++ b/ecscd/src/components/dashboard/sidebar-pane.tsx
@@ -21,6 +21,7 @@ export function DashboardSidebarPane({
     }
 
     listElement.scrollTop = sidebarScrollTop;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- restores scroll state after DOM scrollTop is applied
     setIsListScrolled(sidebarScrollTop > 0);
   }, []);
 

--- a/ecscd/src/components/dashboard/sidebar-pane.tsx
+++ b/ecscd/src/components/dashboard/sidebar-pane.tsx
@@ -21,7 +21,9 @@ export function DashboardSidebarPane({
     }
 
     listElement.scrollTop = sidebarScrollTop;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- restores scroll state after DOM scrollTop is applied
+    // Re-syncs isListScrolled with the cached sidebarScrollTop (module-level, survives remounts)
+    // in case it changed after the initial useState call.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsListScrolled(sidebarScrollTop > 0);
   }, []);
 

--- a/ecscd/src/lib/infrastructure/__tests__/deployment.test.ts
+++ b/ecscd/src/lib/infrastructure/__tests__/deployment.test.ts
@@ -429,9 +429,13 @@ describe("Deployment", () => {
       };
 
       // Mock the service with current task definition
-      const mockService = {
+      const mockService: ServiceDomain = {
+        status: "ACTIVE",
+        desiredCount: 1,
+        runningCount: 1,
         taskDefinition:
           "arn:aws:ecs:us-east-1:123456789012:task-definition/current-family:1",
+        deployments: [],
       };
 
       // Setup mocks
@@ -439,7 +443,7 @@ describe("Deployment", () => {
         status: "Success",
         taskDefinition: targetTaskDefinition,
       });
-      mockAws.describeServices.mockResolvedValue(mockService as unknown as ServiceDomain);
+      mockAws.describeServices.mockResolvedValue(mockService);
       mockAws.describeTaskDefinition.mockResolvedValue(currentTaskDefinition);
 
       // Execute diff
@@ -1090,9 +1094,13 @@ describe("Deployment", () => {
       };
 
       // Mock the service with current task definition
-      const mockService = {
+      const mockService: ServiceDomain = {
+        status: "ACTIVE",
+        desiredCount: 1,
+        runningCount: 1,
         taskDefinition:
           "arn:aws:ecs:us-east-1:123456789012:task-definition/web-app:1",
+        deployments: [],
       };
 
       // Setup mocks
@@ -1100,7 +1108,7 @@ describe("Deployment", () => {
         status: "Success",
         taskDefinition: targetTaskDefinition,
       });
-      mockAws.describeServices.mockResolvedValue(mockService as unknown as ServiceDomain);
+      mockAws.describeServices.mockResolvedValue(mockService);
       mockAws.describeTaskDefinition.mockResolvedValue(currentTaskDefinition);
 
       // Execute diff

--- a/ecscd/src/lib/infrastructure/__tests__/deployment.test.ts
+++ b/ecscd/src/lib/infrastructure/__tests__/deployment.test.ts
@@ -1,7 +1,7 @@
 import { Deployment } from "../deployment";
 import { IAws } from "../interface/aws";
 import { IGithub } from "../interface/github";
-import { ApplicationDomain } from "../../domain/application";
+import { ApplicationDomain, ServiceDomain } from "../../domain/application";
 import { TaskDefinitionSpec } from "../../domain/task-definition";
 import { compareTaskDefinitions } from "../../domain/task-definition-diff";
 
@@ -439,7 +439,7 @@ describe("Deployment", () => {
         status: "Success",
         taskDefinition: targetTaskDefinition,
       });
-      mockAws.describeServices.mockResolvedValue(mockService as any);
+      mockAws.describeServices.mockResolvedValue(mockService as unknown as ServiceDomain);
       mockAws.describeTaskDefinition.mockResolvedValue(currentTaskDefinition);
 
       // Execute diff
@@ -1100,7 +1100,7 @@ describe("Deployment", () => {
         status: "Success",
         taskDefinition: targetTaskDefinition,
       });
-      mockAws.describeServices.mockResolvedValue(mockService as any);
+      mockAws.describeServices.mockResolvedValue(mockService as unknown as ServiceDomain);
       mockAws.describeTaskDefinition.mockResolvedValue(currentTaskDefinition);
 
       // Execute diff


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yaml` を追加。`pull_request` と `main` への push で `tsc --noEmit` / `eslint` / `jest` を実行する
- `eslint.config.mjs` の修正: legacy `FlatCompat` 経由で `next/core-web-vitals`・`next/typescript` を読み込んでいたために `npm run lint` が `TypeError: Converting circular structure to JSON` で必ずクラッシュしていた不具合を修正。`eslint-config-next` が提供するネイティブな flat config (`eslint-config-next/core-web-vitals`, `eslint-config-next/typescript`) を直接 import する形に変更
- lint が動くようになったことで露出した既存の問題を修正 (CI が最初から green で通るように):
  - `react-hooks/set-state-in-effect` ×3 (意図した one-shot な setState だったため `eslint-disable-next-line` + 理由コメントで対応)
  - `@typescript-eslint/no-explicit-any` ×2 (テストのモックを `as any` → `as unknown as ServiceDomain` に)

## Note
MiniStack を使った統合テスト (#95 / #96 で追加予定) は、そちらがマージされた後に別途 CI ジョブとして追加する想定です。

## Test plan
- [x] `npm ci && npx tsc --noEmit && npm run lint && npm test` (ローカルで CI と同じコマンドを実行し確認)